### PR TITLE
fix: add temporary file save before verifications

### DIFF
--- a/commands/download.py
+++ b/commands/download.py
@@ -1,11 +1,11 @@
 from commands.base import Command
-from src.download import DownloadManager
-from src.parser import ParseURL
 from src.api import GitHubAPI
 from src.app_config import AppConfigManager
-from src.verify import VerificationManager
+from src.download import DownloadManager
 from src.file_handler import FileHandler
 from src.global_config import GlobalConfigManager
+from src.parser import ParseURL
+from src.verify import VerificationManager
 
 
 class DownloadCommand(Command):
@@ -45,6 +45,9 @@ class DownloadCommand(Command):
         app_config.sha_name = api.sha_name
         app_config.hash_type = api.hash_type
 
+        # Save temporary configuration
+        app_config.temp_save_config()
+
         # 4. Use DownloadManager to download the AppImage
         download = DownloadManager(api)
         download.download()  # Pass the appimage URL to download method
@@ -68,9 +71,6 @@ class DownloadCommand(Command):
                 return
         else:
             print("Skipping verification for beta version")
-
-        # Save temporary configuration
-        app_config.temp_save_config()
 
         # Handle file operations
         file_handler = FileHandler(

--- a/config_files_examples/joplin.json
+++ b/config_files_examples/joplin.json
@@ -1,10 +1,9 @@
 {
-  "owner": "laurent22",
-  "repo": "joplin",
-  "version": "3.2.12",
-  "sha_name": "Joplin-3.2.12.AppImage.sha512",
-  "hash_type": "sha512",
-  "appimage_name": "Joplin-3.2.12.AppImage",
-  "arch_keyword": ".appimage"
+    "owner": "laurent22",
+    "repo": "joplin",
+    "version": "3.2.13",
+    "sha_name": "latest-linux.yml",
+    "hash_type": "sha512",
+    "appimage_name": "Joplin-3.2.13.AppImage",
+    "arch_keyword": ".appimage"
 }
-


### PR DESCRIPTION
Make it more easy to debug.
Use exact sha_name for joplin to prevent complex loop for detecting with new version.