### PR TITLE
feat: add asset digest verification support

### DIFF
--- a/src/api/assets.py
+++ b/src/api/assets.py
@@ -114,6 +114,7 @@ class ReleaseInfo:
     is_prerelease: bool = False
     published_at: Optional[str] = None
     extracted_hash_from_body: Optional[str] = None # For hash extracted from release body
+    asset_digest: Optional[str] = None # For GitHub API asset digest verification
     raw_assets: List[Dict[str, Any]] = field(default_factory=list) # Added for storing all assets
 
     @classmethod
@@ -138,6 +139,7 @@ class ReleaseInfo:
             sha_url=asset_info.get("sha_url"),
             hash_type=asset_info.get("hash_type"),
             extracted_hash_from_body=asset_info.get("extracted_hash_from_body"), # Get new field
+            asset_digest=asset_info.get("asset_digest"), # Get asset digest field
             arch_keyword=asset_info.get("arch_keyword"),
             release_notes=release_data.get("body", ""),
             release_url=release_data.get("html_url", ""),

--- a/src/api/github_api.py
+++ b/src/api/github_api.py
@@ -44,6 +44,7 @@ class GitHubAPI:
         self.appimage_url: Optional[str] = None
         self.sha_url: Optional[str] = None
         self.extracted_hash_from_body: Optional[str] = None  # To store hash from release body
+        self.asset_digest: Optional[str] = None  # To store GitHub API asset digest
         self._headers = GitHubAuthManager.get_auth_headers()
         self._icon_manager = IconManager()
         self._release_fetcher = ReleaseManager(owner, repo)
@@ -205,11 +206,13 @@ class GitHubAPI:
             self.sha_url = sha_mgr.sha_url
             self.hash_type = sha_mgr.hash_type
             self.extracted_hash_from_body = sha_mgr.extracted_hash_from_body
+            self.asset_digest = sha_mgr.asset_digest
         else:
             self.sha_name = None
             self.sha_url = None
             self.hash_type = None
             self.extracted_hash_from_body = None
+            self.asset_digest = None
 
         asset_info_dict = {
             "owner": self.owner,
@@ -221,6 +224,7 @@ class GitHubAPI:
             "sha_url": self.sha_url,
             "hash_type": self.hash_type,
             "extracted_hash_from_body": self.extracted_hash_from_body,
+            "asset_digest": self.asset_digest,
             "arch_keyword": self._arch_keyword,
         }
 

--- a/src/commands/download.py
+++ b/src/commands/download.py
@@ -82,6 +82,7 @@ class DownloadCommand(Command):
                         sha_url=api.sha_url,
                         appimage_name=api.appimage_name,  # Keep the original filename for logging
                         hash_type=api.hash_type,
+                        asset_digest=api.asset_digest,
                     )
 
                     # Set the full path to the downloaded file

--- a/src/commands/install_app.py
+++ b/src/commands/install_app.py
@@ -211,6 +211,7 @@ class InstallAppCommand(Command):
                             sha_url=api.sha_url or "",
                             appimage_name=api.appimage_name,
                             hash_type=api.hash_type or "sha256",
+                            asset_digest=api.asset_digest,
                         )
 
                         # Set the full path to the downloaded file

--- a/src/commands/update_base.py
+++ b/src/commands/update_base.py
@@ -521,6 +521,7 @@ class BaseUpdateCommand(Command):
             sha_url=github_api.sha_url,
             appimage_name=str(github_api.appimage_name),
             hash_type=github_api.hash_type or "sha256",
+            asset_digest=github_api.asset_digest,
         )
 
         # Set downloaded file path for verification

--- a/src/download.py
+++ b/src/download.py
@@ -491,5 +491,6 @@ class DownloadManager:
             appimage_path=downloaded_file,
             hash_type=self.github_api.hash_type if self.github_api.hash_type is not None else "sha256",
             direct_expected_hash=direct_hash_to_pass,
+            asset_digest=self.github_api.asset_digest,
         )
         return verifier.verify_appimage(cleanup_on_failure=True)


### PR DESCRIPTION
Implements GitHub API asset digest-based verification as the highest
priority verification method, falling back to existing SHA file and
release body extraction methods when digest is unavailable.

- Add asset_digest field to ReleaseInfo and GitHubAPI classes
- Extract digest from GitHub API asset metadata in SHAManager
- Support sha256/sha512 digest verification in VerificationManager
- Pass asset_digest through download and install command chains
- This will also fix the zen-browser verification issue.