### PR TITLE
fix(prereleases): handle missing prereleases gracefully in update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.1.2-alpha
 ## v1.1.0-alpha
 ### BREAKING CHANGES
 This release implement new backup commands and features.

--- a/my_unicorn/update.py
+++ b/my_unicorn/update.py
@@ -236,7 +236,16 @@ class UpdateManager:
             fetcher = GitHubReleaseFetcher(owner, repo, session)
             if should_use_prerelease:
                 logger.debug(f"Fetching latest prerelease for {owner}/{repo}")
-                release_data = await fetcher.fetch_latest_prerelease()
+                try:
+                    release_data = await fetcher.fetch_latest_prerelease()
+                except ValueError as e:
+                    if "No prereleases found" in str(e):
+                        logger.warning(
+                            f"No prereleases found for {owner}/{repo}, falling back to latest release"
+                        )
+                        release_data = await fetcher.fetch_latest_release()
+                    else:
+                        raise
             else:
                 release_data = await fetcher.fetch_latest_release()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'my-unicorn'
-version = '1.1.1-alpha'
+version = '1.1.2-alpha'
 maintainers = [{ name = "Cyber-Syntax" }]
 license = { text = "GPL-3.0-or-later" }
 description = 'It downloads/updates appimages via GitHub API. It also validates the appimage with SHA256 and SHA512.'


### PR DESCRIPTION
Log a warning and fall back to the latest release if no prereleases are found during the fetch operation.