### PR TITLE
feat: add new application entries

### DIFF
--- a/my_unicorn/catalog/affine.json
+++ b/my_unicorn/catalog/affine.json
@@ -1,0 +1,24 @@
+{
+    "appimage": {
+        "rename": "affine",
+        "name_template": "",
+        "characteristic_suffix": []
+    },
+    "owner": "toeverything",
+    "repo": "AFFiNE",
+    "github": {
+        "repo": true,
+        "prerelease": false
+    },
+    "verification": {
+        "digest": true,
+        "skip": false,
+        "checksum_file": "",
+        "checksum_hash_type": "sha256"
+    },
+    "icon": {
+        "extraction": true,
+        "url": "",
+        "name": "affine.png"
+    }
+}

--- a/my_unicorn/catalog/affine.json
+++ b/my_unicorn/catalog/affine.json
@@ -1,11 +1,11 @@
 {
+    "owner": "toeverything",
+    "repo": "AFFiNE",
     "appimage": {
         "rename": "affine",
         "name_template": "",
         "characteristic_suffix": []
     },
-    "owner": "toeverything",
-    "repo": "AFFiNE",
     "github": {
         "repo": true,
         "prerelease": false

--- a/my_unicorn/catalog/anytype.json
+++ b/my_unicorn/catalog/anytype.json
@@ -1,0 +1,24 @@
+{
+    "appimage": {
+        "rename": "anytype",
+        "name_template": "",
+        "characteristic_suffix": []
+    },
+    "owner": "anyproto",
+    "repo": "anytype-ts",
+    "github": {
+        "repo": true,
+        "prerelease": false
+    },
+    "verification": {
+        "digest": true,
+        "skip": false,
+        "checksum_file": "",
+        "checksum_hash_type": "sha256"
+    },
+    "icon": {
+        "extraction": true,
+        "url": "",
+        "name": "anytype.png"
+    }
+}

--- a/my_unicorn/catalog/beekeper-studio.json
+++ b/my_unicorn/catalog/beekeper-studio.json
@@ -1,8 +1,8 @@
 {
-    "owner": "anyproto",
-    "repo": "anytype-ts",
+    "owner": "beekeeper-studio",
+    "repo": "beekeeper-studio",
     "appimage": {
-        "rename": "anytype",
+        "rename": "beekeeper-studio",
         "name_template": "",
         "characteristic_suffix": []
     },
@@ -19,6 +19,6 @@
     "icon": {
         "extraction": true,
         "url": "",
-        "name": "anytype.png"
+        "name": "beekeeper-studio.png"
     }
 }

--- a/my_unicorn/catalog/cherrytree.json
+++ b/my_unicorn/catalog/cherrytree.json
@@ -1,8 +1,8 @@
 {
-    "owner": "anyproto",
-    "repo": "anytype-ts",
+    "owner": "giuspen",
+    "repo": "cherrytree",
     "appimage": {
-        "rename": "anytype",
+        "rename": "cherrytree",
         "name_template": "",
         "characteristic_suffix": []
     },
@@ -19,6 +19,6 @@
     "icon": {
         "extraction": true,
         "url": "",
-        "name": "anytype.png"
+        "name": "cherrytree.png"
     }
 }

--- a/my_unicorn/catalog/drawio.json
+++ b/my_unicorn/catalog/drawio.json
@@ -1,8 +1,8 @@
 {
-    "owner": "anyproto",
-    "repo": "anytype-ts",
+    "owner": "jgraph",
+    "repo": "drawio-desktop",
     "appimage": {
-        "rename": "anytype",
+        "rename": "drawio-desktop",
         "name_template": "",
         "characteristic_suffix": []
     },
@@ -19,6 +19,6 @@
     "icon": {
         "extraction": true,
         "url": "",
-        "name": "anytype.png"
+        "name": "drawio-desktop.png"
     }
 }

--- a/my_unicorn/catalog/endless-sky.json
+++ b/my_unicorn/catalog/endless-sky.json
@@ -1,8 +1,8 @@
 {
-    "owner": "pbek",
-    "repo": "QOwnNotes",
+    "owner": "endless-sky",
+    "repo": "endless-sky",
     "appimage": {
-        "rename": "qownnotes",
+        "rename": "endless-sky",
         "name_template": "{repo}-{characteristic_suffix}.AppImage",
         "characteristic_suffix": ["x86_64.AppImage"]
     },
@@ -18,7 +18,7 @@
     },
     "icon": {
         "extraction": true,
-        "url": "https://raw.githubusercontent.com/pbek/QOwnNotes/develop/icons/icon.png",
-        "name": "qownnotes.png"
+        "url": "",
+        "name": "endless-sky.png"
     }
 }

--- a/my_unicorn/catalog/freecad.json
+++ b/my_unicorn/catalog/freecad.json
@@ -1,8 +1,8 @@
 {
-    "owner": "anyproto",
-    "repo": "anytype-ts",
+    "owner": "FreeCAD",
+    "repo": "FreeCAD",
     "appimage": {
-        "rename": "anytype",
+        "rename": "freecad",
         "name_template": "",
         "characteristic_suffix": []
     },
@@ -19,6 +19,6 @@
     "icon": {
         "extraction": true,
         "url": "",
-        "name": "anytype.png"
+        "name": "freecad.png"
     }
 }

--- a/my_unicorn/catalog/freetube.json
+++ b/my_unicorn/catalog/freetube.json
@@ -17,6 +17,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/FreeTubeApp/FreeTube/development/_icons/icon.svg",
         "name": "freetube.svg"
     }

--- a/my_unicorn/catalog/heroicgameslauncher.json
+++ b/my_unicorn/catalog/heroicgameslauncher.json
@@ -19,6 +19,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/Heroic-Games-Launcher/HeroicGamesLauncher/main/public/icon.png",
         "name": "heroicgameslauncher.png"
     }

--- a/my_unicorn/catalog/joplin.json
+++ b/my_unicorn/catalog/joplin.json
@@ -19,6 +19,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/LinuxIcons/256x256.png",
         "name": "joplin.png"
     }

--- a/my_unicorn/catalog/kdiskmark.json
+++ b/my_unicorn/catalog/kdiskmark.json
@@ -19,6 +19,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/JonMagon/KDiskMark/master/data/icons/128-apps-kdiskmark.png",
         "name": "kdiskmark.png"
     }

--- a/my_unicorn/catalog/legcord.json
+++ b/my_unicorn/catalog/legcord.json
@@ -1,8 +1,8 @@
 {
-    "owner": "anyproto",
-    "repo": "anytype-ts",
+    "owner": "Legcord",
+    "repo": "Legcord",
     "appimage": {
-        "rename": "anytype",
+        "rename": "legcord",
         "name_template": "",
         "characteristic_suffix": []
     },
@@ -11,14 +11,14 @@
         "prerelease": false
     },
     "verification": {
-        "digest": true,
+        "digest": false,
         "skip": false,
-        "checksum_file": "",
+        "checksum_file": "latest-linux.yml",
         "checksum_hash_type": "sha256"
     },
     "icon": {
         "extraction": true,
         "url": "",
-        "name": "anytype.png"
+        "name": "legcord.png"
     }
 }

--- a/my_unicorn/catalog/logseq.json
+++ b/my_unicorn/catalog/logseq.json
@@ -21,6 +21,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/logseq/logseq/master/resources/icons/logseq.png",
         "name": "logseq.png"
     }

--- a/my_unicorn/catalog/obsidian.json
+++ b/my_unicorn/catalog/obsidian.json
@@ -19,6 +19,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "",
         "name": "obsidian.png"
     }

--- a/my_unicorn/catalog/siyuan.json
+++ b/my_unicorn/catalog/siyuan.json
@@ -20,6 +20,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/siyuan-note/siyuan/master/app/src/assets/icon.png",
         "name": "siyuan.png"
     }

--- a/my_unicorn/catalog/standard-notes.json
+++ b/my_unicorn/catalog/standard-notes.json
@@ -20,6 +20,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/standardnotes/app/main/packages/clipper/images/icon128.png",
         "name": "standard-notes.png"
     }

--- a/my_unicorn/catalog/super-productivity.json
+++ b/my_unicorn/catalog/super-productivity.json
@@ -20,6 +20,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/johannesjo/super-productivity/master/src/assets/icons/favicon-192x192.png",
         "name": "super-productivity.png"
     }

--- a/my_unicorn/catalog/tagspaces.json
+++ b/my_unicorn/catalog/tagspaces.json
@@ -21,6 +21,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/tagspaces/tagspaces/master/assets/icon.png",
         "name": "tagspaces.png"
     }

--- a/my_unicorn/catalog/weektodo.json
+++ b/my_unicorn/catalog/weektodo.json
@@ -19,6 +19,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/manuelernestog/weekToDo/master/public/icon.png",
         "name": "weektodo.png"
     }

--- a/my_unicorn/catalog/zen-browser.json
+++ b/my_unicorn/catalog/zen-browser.json
@@ -20,6 +20,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/zen-browser/desktop/dev/docs/assets/zen-black.svg",
         "name": "zen-browser.svg"
     }

--- a/my_unicorn/catalog/zettlr.json
+++ b/my_unicorn/catalog/zettlr.json
@@ -20,6 +20,7 @@
         "checksum_hash_type": "sha256"
     },
     "icon": {
+        "extraction": true,
         "url": "https://raw.githubusercontent.com/Zettlr/Zettlr/master/resources/icons/png/256x256.png",
         "name": "zettlr.png"
     }


### PR DESCRIPTION
This pull request adds new application entries and improves icon extraction handling in the `my_unicorn/catalog` directory. The main changes are the addition of several new application JSON files and updates to ensure icon extraction is enabled for existing entries.

**New application entries:**

* Added new catalog entries for `affine`, `anytype`, `beekeeper-studio`, `cherrytree`, `drawio-desktop`, `endless-sky`, `freecad`, and `legcord`, each with metadata for repository, AppImage configuration, verification, and icon extraction. [[1]](diffhunk://#diff-0d8539662491a42f77b92fc210b3aa67f267aa540c1410afc7edb143e5dc80aeR1-R24) [[2]](diffhunk://#diff-7899ae5a7399e65acfa8e2e3fc23aee6dac6aa873759c9f6f70e279db869221dR1-R24) [[3]](diffhunk://#diff-c0041a3076811d02d20d004e52c6110f4558a3fa42ac8bca9798c8edbf89c821R1-R24) [[4]](diffhunk://#diff-2148507da6655b3b4e066b9246bd5bdf501372a963b562c457a75ff1ed2aa4e0R1-R24) [[5]](diffhunk://#diff-a600ed184a18f1a9894810710a331f81334bda237b3a167e0c51144ec2cf5459R1-R24) [[6]](diffhunk://#diff-ddd9b9d6a05756b7ccc0159fde76bdf420df5cf38f12ea15182ab49130df8438R1-R24) [[7]](diffhunk://#diff-71f611d311b4974f9814b985e97e03360cdde3e507059cfd3782646f7f17e44dR1-R24) [[8]](diffhunk://#diff-845e0242d840149c0b5ba4739c610a4fc3dcf388e7b51601295a918ac8b939e7R1-R24)

**Icon extraction improvements:**

* Enabled `"extraction": true` for the `icon` field in existing catalog entries, ensuring icons are properly extracted for `freetube`, `heroicgameslauncher`, `joplin`, `kdiskmark`, `logseq`, `obsidian`, `qownnotes`, `siyuan`, `standard-notes`, `super-productivity`, `tagspaces`, and `weektodo`. [[1]](diffhunk://#diff-0857fa519e91d655271d7acea43124a4935b16f1aa0b4611fbe15b727d2a73d3R20) [[2]](diffhunk://#diff-35a8752c93bed86f4a3d64d8dd1a3dce24320e8fd86ffd34a0c5bcc737b8a001R22) [[3]](diffhunk://#diff-94a4ffc6e406a6b0ea67b93f5f6e01518a0be7510cc08ab1d8d47246b8538a41R22) [[4]](diffhunk://#diff-af2fd76dae142a1792d20dba392d2e14355076aaabf3211d2ae2d272e25f6f01R22) [[5]](diffhunk://#diff-f8df5f1b59ba3dd0daa2e9042d1327ad8cf4e526042dd71b752d95c07a751963R24) [[6]](diffhunk://#diff-952f7a2d5fb4929d947da706ec12b03d929bccdce3c1b9830318b999266ac179R22) [[7]](diffhunk://#diff-15e3878098889004e64cccfc85c2f3ada515a8418577f6d7c9bf7fdc4d60e1b9R20-R22) [[8]](diffhunk://#diff-f32c34157b4a00744a858658e0df1afb594fc8438b450fbcc9922a975110bc46R23) [[9]](diffhunk://#diff-fc62177f030740afc0962475e411952aeab50bdade92a7be123fde63131149f1R23) [[10]](diffhunk://#diff-0469a74d8177e073d279f8922de905d7785aa19ee0e7ad1e8c68686c3a8c1a34R23) [[11]](diffhunk://#diff-eee53cc9c7c7487b01255898629400d3b70316bf52847ad754a52e12f42334f4R24) [[12]](diffhunk://#diff-8124bfbec806cdc74e1e19cb260d84714eb481ff339dd8cfe4f1489e74b442b1R22)

**Verification configuration:**

* All new entries include verification settings, typically using SHA256 digest, and some specify checksum files for additional validation. [[1]](diffhunk://#diff-0d8539662491a42f77b92fc210b3aa67f267aa540c1410afc7edb143e5dc80aeR1-R24) [[2]](diffhunk://#diff-7899ae5a7399e65acfa8e2e3fc23aee6dac6aa873759c9f6f70e279db869221dR1-R24) [[3]](diffhunk://#diff-c0041a3076811d02d20d004e52c6110f4558a3fa42ac8bca9798c8edbf89c821R1-R24) [[4]](diffhunk://#diff-2148507da6655b3b4e066b9246bd5bdf501372a963b562c457a75ff1ed2aa4e0R1-R24) [[5]](diffhunk://#diff-a600ed184a18f1a9894810710a331f81334bda237b3a167e0c51144ec2cf5459R1-R24) [[6]](diffhunk://#diff-ddd9b9d6a05756b7ccc0159fde76bdf420df5cf38f12ea15182ab49130df8438R1-R24) [[7]](diffhunk://#diff-71f611d311b4974f9814b985e97e03360cdde3e507059cfd3782646f7f17e44dR1-R24) [[8]](diffhunk://#diff-845e0242d840149c0b5ba4739c610a4fc3dcf388e7b51601295a918ac8b939e7R1-R24)

**AppImage configuration:**

* AppImage settings are standardized across new entries, with options for renaming, templates, and characteristic suffixes where needed (e.g., `endless-sky`).

**Repository metadata:**

* Each new entry specifies the GitHub repository owner and name, and sets prerelease handling as false. [[1]](diffhunk://#diff-0d8539662491a42f77b92fc210b3aa67f267aa540c1410afc7edb143e5dc80aeR1-R24) [[2]](diffhunk://#diff-7899ae5a7399e65acfa8e2e3fc23aee6dac6aa873759c9f6f70e279db869221dR1-R24) [[3]](diffhunk://#diff-c0041a3076811d02d20d004e52c6110f4558a3fa42ac8bca9798c8edbf89c821R1-R24) [[4]](diffhunk://#diff-2148507da6655b3b4e066b9246bd5bdf501372a963b562c457a75ff1ed2aa4e0R1-R24) [[5]](diffhunk://#diff-a600ed184a18f1a9894810710a331f81334bda237b3a167e0c51144ec2cf5459R1-R24) [[6]](diffhunk://#diff-ddd9b9d6a05756b7ccc0159fde76bdf420df5cf38f12ea15182ab49130df8438R1-R24) [[7]](diffhunk://#diff-71f611d311b4974f9814b985e97e03360cdde3e507059cfd3782646f7f17e44dR1-R24) [[8]](diffhunk://#diff-845e0242d840149c0b5ba4739c610a4fc3dcf388e7b51601295a918ac8b939e7R1-R24)