### PR TITLE
Add autocomplete installation for bash and zsh shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.7.1-alpha
 ## v1.7.0-alpha
 # CHANGES
 This release refactors the codebase for improved code readability, maintainability and performance.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Turkish: [README.tr.md](README.tr.md)
 
 > [!CAUTION]
+>
 > - This project is in a **alpha phase** due to limited testing at this time.
 > - **Important:** Follow the instructions in the **Releases section** when updating the script.
 > - **Supported OS:** Currently, only Linux is supported.
@@ -9,6 +10,7 @@ Turkish: [README.tr.md](README.tr.md)
 
 > [!NOTE]
 > My Unicorn is a command-line tool to manage AppImages on Linux. It allows users to install, update, and manage AppImages from GitHub repositories easily. It's designed to simplify the process of handling AppImages, making it more convenient for users to keep their applications up-to-date.
+>
 > - Detailed information: [wiki.md](docs/wiki.md)
 
 - **Supported Applications:**
@@ -16,7 +18,7 @@ Turkish: [README.tr.md](README.tr.md)
     - Applications without verification (developer doesn't provide hash):
         - WeekToDo
         - FreeTube
-            - Related issue: https://github.com/FreeTubeApp/FreeTube/issues/4720)
+            - Related issue: <https://github.com/FreeTubeApp/FreeTube/issues/4720>)
     - More can be found in the [catalog](my_unicorn/catalog/) folder.
 - **Supported hash types:**
     - sha256, sha512
@@ -40,13 +42,24 @@ Turkish: [README.tr.md](README.tr.md)
     sh my-unicorn-installer.sh install
     ```
 
-3. Start using my-unicorn:
+3. Add autocomplete (optional):
+
+    ```bash
+    # auto-detect your shell and install autocomplete
+    sh my-unicorn-installer.sh autocomplete
+
+    # or manually add autocomplete for bash or zsh
+    sh my-unicorn-installer.sh autocomplete bash
+    sh my-unicorn-installer.sh autocomplete zsh
+    ```
+
+4. Start using my-unicorn:
 
     ```bash
     my-unicorn --help # to see the command options
     ```
 
-## For using uncompatible apps (installing with URL):
+## For using uncompatible apps (installing with URL)
 
 > [!IMPORTANT]
 > If you want to install an uncompatible app, you'll need to know some information about the application.

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# my-unicorn bash completion script
+# Source this file to enable tab completion for my-unicorn command
+
+_my_unicorn_completion() {
+    local cur prev commands
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    
+    # Available commands
+    commands="install update self-update list remove backup cache auth config"
+    
+    # Global options
+    local global_opts="--help --version"
+    
+    # Command-specific options
+    local install_opts="--concurrency --no-icon --no-verify --no-desktop --verbose --help"
+    local update_opts="--check-only --refresh-cache --verbose --help"
+    local self_update_opts="--check-only --help"
+    local list_opts="--available --help"
+    local remove_opts="--keep-config --help"
+    local backup_opts="--restore-last --restore-version --list-backups --cleanup --info --migrate --help"
+    local cache_opts="clear stats --help"
+    local cache_clear_opts="--all --help"
+    local auth_opts="--save-token --remove-token --status --help"
+    local config_opts="--show --reset --help"
+    
+    # If we're completing the first argument (command)
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "${commands} ${global_opts}" -- "${cur}")
+        return 0
+    fi
+    
+    # Get the command being used
+    local command="${COMP_WORDS[1]}"
+    
+    case "${command}" in
+        install)
+            case "${prev}" in
+                --concurrency)
+                    # Numeric value expected
+                    COMPREPLY=()
+                    ;;
+                *)
+                    if [[ ${cur} == -* ]]; then
+                        mapfile -t COMPREPLY < <(compgen -W "${install_opts}" -- "${cur}")
+                    else
+                        # Complete with app names or URLs
+                        COMPREPLY=()
+                    fi
+                    ;;
+            esac
+            ;;
+        update)
+            if [[ ${cur} == -* ]]; then
+                mapfile -t COMPREPLY < <(compgen -W "${update_opts}" -- "${cur}")
+            else
+                # Complete with installed app names
+                COMPREPLY=()
+            fi
+            ;;
+        self-update)
+            mapfile -t COMPREPLY < <(compgen -W "${self_update_opts}" -- "${cur}")
+            ;;
+        list)
+            mapfile -t COMPREPLY < <(compgen -W "${list_opts}" -- "${cur}")
+            ;;
+        remove)
+            if [[ ${cur} == -* ]]; then
+                mapfile -t COMPREPLY < <(compgen -W "${remove_opts}" -- "${cur}")
+            else
+                # Complete with installed app names
+                COMPREPLY=()
+            fi
+            ;;
+        backup)
+            case "${prev}" in
+                --restore-version)
+                    # Version string expected
+                    COMPREPLY=()
+                    ;;
+                *)
+                    if [[ ${cur} == -* ]]; then
+                        mapfile -t COMPREPLY < <(compgen -W "${backup_opts}" -- "${cur}")
+                    else
+                        # Complete with app names
+                        COMPREPLY=()
+                    fi
+                    ;;
+            esac
+            ;;
+        cache)
+            if [[ ${COMP_CWORD} -eq 2 ]]; then
+                mapfile -t COMPREPLY < <(compgen -W "${cache_opts}" -- "${cur}")
+            elif [[ ${COMP_WORDS[2]} == "clear" ]]; then
+                if [[ ${cur} == -* ]]; then
+                    mapfile -t COMPREPLY < <(compgen -W "${cache_clear_opts}" -- "${cur}")
+                else
+                    # Complete with app names
+                    COMPREPLY=()
+                fi
+            fi
+            ;;
+        auth)
+            mapfile -t COMPREPLY < <(compgen -W "${auth_opts}" -- "${cur}")
+            ;;
+        config)
+            mapfile -t COMPREPLY < <(compgen -W "${config_opts}" -- "${cur}")
+            ;;
+        *)
+            COMPREPLY=()
+            ;;
+    esac
+    
+    return 0
+}
+
+# Register the completion function
+complete -F _my_unicorn_completion my-unicorn

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,0 +1,123 @@
+#compdef my-unicorn
+
+# my-unicorn zsh completion script
+# Add this to your zsh completions directory or source it in your .zshrc
+
+_my_unicorn() {
+    local -a commands
+    local state line
+    
+    # Define available commands
+    commands=(
+        'install:Install AppImages from catalog or URLs'
+        'update:Update installed AppImages'
+        'self-update:Update my-unicorn itself from GitHub'
+        'list:List installed AppImages'
+        'remove:Remove installed AppImages'
+        'backup:Manage AppImage backups and restore'
+        'cache:Manage release data cache for better performance'
+        'auth:Manage GitHub authentication'
+        'config:Manage configuration'
+    )
+
+    _arguments -C \
+        '1: :->command' \
+        '*: :->args' \
+        && return 0
+
+    case $state in
+        command)
+            _describe 'my-unicorn commands' commands
+            _values 'global options' \
+                '--help[Show help information]' \
+                '--version[Show version information]'
+            ;;
+        args)
+            case ${line[1]} in
+                install)
+                    _arguments \
+                        '(--concurrency --no-icon --no-verify --no-desktop --verbose)--concurrency[Maximum number of parallel installs]:number:' \
+                        '(--concurrency --no-icon --no-verify --no-desktop --verbose)--no-icon[Skip downloading application icons]' \
+                        '(--concurrency --no-icon --no-verify --no-desktop --verbose)--no-verify[Skip AppImage verification]' \
+                        '(--concurrency --no-icon --no-verify --no-desktop --verbose)--no-desktop[Skip desktop entry creation]' \
+                        '(--concurrency --no-icon --no-verify --no-desktop --verbose)--verbose[Show detailed logging during installation]' \
+                        '--help[Show help information]' \
+                        '1:app app:_files'
+                    ;;
+                update)
+                    _arguments \
+                        '(--check-only --refresh-cache --verbose)--check-only[Only check for updates without installing]' \
+                        '(--check-only --refresh-cache --verbose)--refresh-cache[Bypass cache and fetch fresh data from GitHub API]' \
+                        '(--check-only --refresh-cache --verbose)--verbose[Show detailed logging during update]' \
+                        '--help[Show help information]' \
+                        '1:app app:_files'
+                    ;;
+                self-update)
+                    _arguments \
+                        '(--check-only)--check-only[Only check for updates without installing]' \
+                        '--help[Show help information]' \
+                        '1:app app:_files'
+                    ;;
+                list)
+                    _arguments \
+                        '(--available)--available[Show available applications from catalog]' \
+                        '--help[Show help information]' \
+                        '1:app app:_files'
+                    ;;
+                remove)
+                    _arguments \
+                        '(--keep-config)--keep-config[Keep configuration files]' \
+                        '--help[Show help information]' \
+                        "1:app app:_files"
+                    ;;
+                backup)
+                    _arguments \
+                        '(--restore-last --restore-version --list-backups --cleanup --info --migrate)--restore-last[Restore the latest backup version]' \
+                        '(--restore-last --restore-version --list-backups --cleanup --info --migrate)--restore-version[Restore a specific version]:version:' \
+                        '(--restore-last --restore-version --list-backups --cleanup --info --migrate)--list-backups[List available backups for the specified app]' \
+                        '(--restore-last --restore-version --list-backups --cleanup --info --migrate)--cleanup[Clean up old backups according to max_backup setting]' \
+                        '(--restore-last --restore-version --list-backups --cleanup --info --migrate)--info[Show detailed backup information]' \
+                        '(--restore-last --restore-version --list-backups --cleanup --info --migrate)--migrate[Migrate old backup files to new folder-based format]' \
+                        '--help[Show help information]' \
+                        '1:app app:_files'
+                    ;;
+                cache)
+                    local -a cache_commands
+                    cache_commands=(
+                        'clear:Clear cache entries'
+                        'stats:Show cache statistics and storage info'
+                    )
+                    
+                    if [[ ${#line} -eq 2 ]]; then
+                        _describe 'cache commands' cache_commands
+                        _values 'cache options' '--help[Show help information]'
+                    elif [[ ${line[2]} == "clear" ]]; then
+                        _arguments \
+                            '--all[Clear all cache entries]' \
+                            '--help[Show help information]' \
+                            '1:app app:_files'
+                    elif [[ ${line[2]} == "stats" ]]; then
+                        _arguments '--help[Show help information]'
+                    fi
+                    ;;
+                auth)
+                    _arguments \
+                        '(--save-token --remove-token --status)--save-token[Save GitHub authentication token]' \
+                        '(--save-token --remove-token --status)--remove-token[Remove GitHub authentication token]' \
+                        '(--save-token --remove-token --status)--status[Show authentication status]' \
+                        '--help[Show help information]' \
+                        '1:app app:_files'
+                    ;;
+                config)
+                    _arguments \
+                        '(--show --reset)--show[Show current configuration]' \
+                        '(--show --reset)--reset[Reset configuration to defaults]' \
+                        '--help[Show help information]' \
+                        '1:app app:_files'
+                    ;;
+            esac
+            ;;
+    esac
+
+    return 0
+}

--- a/my-unicorn-installer.sh
+++ b/my-unicorn-installer.sh
@@ -123,7 +123,7 @@ copy_source_to_install_dir() {
   mkdir -p "$INSTALL_DIR"
 
   # Source files to copy
-  for item in my_unicorn scripts pyproject.toml "$(basename "$0")"; do
+  for item in my_unicorn scripts pyproject.toml autocomplete "$(basename "$0")"; do
     local src_path="$src_dir/$item"
     local dst_path="$INSTALL_DIR/$item"
     if [ -e "$src_path" ]; then
@@ -180,16 +180,202 @@ update_my_unicorn() {
   echo "✅ Update complete."
 }
 
+# -- Autocomplete functions --------------------------------------------------
+
+# Function to install bash completion
+install_bash_completion() {
+    echo "Installing Bash completion..."
+    
+    local bash_autocomplete_src="$INSTALL_DIR/autocomplete/bash_autocomplete"
+    
+    # Check if source file exists
+    if [[ ! -f "$bash_autocomplete_src" ]]; then
+        echo "Bash autocomplete file not found: $bash_autocomplete_src"
+        return 1
+    fi
+
+    # Add to bashrc
+    if ! grep -q "source.*bash_autocomplete" ~/.bashrc 2>/dev/null; then
+        echo "" >> ~/.bashrc
+        echo "# my-unicorn completion" >> ~/.bashrc
+        echo "source \"$bash_autocomplete_src\"" >> ~/.bashrc
+        echo "Bash completion added to ~/.bashrc"
+    else
+        print_warning "Bash completion already exists in ~/.bashrc"
+    fi
+}
+
+# Determine if user uses .config/zsh
+determine_zsh_config_dir() {
+    if [[ -d "${XDG_CONFIG_HOME:-$HOME/.config}/zsh" ]]; then
+        echo "${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
+    elif [[ -d "$HOME/.config/zsh" ]]; then
+        echo "$HOME/.config/zsh"
+    else
+        echo "$HOME/.zsh"
+    fi
+}
+
+# Function to install zsh completion
+install_zsh_completion() {
+    echo "Installing Zsh completion..."
+
+    local zsh_autocomplete_src="$INSTALL_DIR/autocomplete/zsh_autocomplete"
+    
+    # Check if source file exists
+    if [[ ! -f "$zsh_autocomplete_src" ]]; then
+        echo "Zsh autocomplete file not found: $zsh_autocomplete_src"
+        return 1
+    fi
+
+    # Determine zsh config directory
+    local zsh_config_dir
+    zsh_config_dir=$(determine_zsh_config_dir)
+    echo "Using zsh config directory: $zsh_config_dir"
+    
+    # Create user completion directory if it doesn't exist
+    mkdir -p "$zsh_config_dir/completions"
+    
+    # Copy completion file
+    cp "$zsh_autocomplete_src" "$zsh_config_dir/completions/_my-unicorn"
+    echo "Zsh completion installed to $zsh_config_dir/completions/_my-unicorn"
+
+    # Update zshrc if needed. Ensure fpath is present BEFORE any compinit call
+    local rc_file="$zsh_config_dir/.zshrc"
+    # Ensure rc_file exists
+    touch "$rc_file"
+
+    local comment_line="# Added by my-unicorn to enable shell completion"
+    local fpath_line="fpath=($zsh_config_dir/completions \$fpath)"
+
+    # If exact fpath line already exists, do nothing. Otherwise insert it
+    if grep -qF "$fpath_line" "$rc_file" 2>/dev/null; then
+        echo "fpath already configured in $rc_file"
+    else
+        if grep -q "compinit" "$rc_file" 2>/dev/null; then
+            # Insert comment + fpath line just before the first compinit occurrence
+            awk -v cl="$comment_line" -v fl="$fpath_line" 'BEGIN{printed=0} { if(!printed && $0 ~ /compinit/){ print cl; print fl; printed=1 } print } END{ if(!printed){ print cl; print fl } }' "$rc_file" > "$rc_file.tmp" && mv "$rc_file.tmp" "$rc_file"
+            echo "Inserted fpath (with comment) before compinit in $rc_file"
+        else
+            # Prepend comment + fpath to the top of the file
+            printf "%s\n%s\n\n%s\n" "$comment_line" "$fpath_line" "$(cat "$rc_file")" > "$rc_file.tmp" && mv "$rc_file.tmp" "$rc_file"
+            echo "Prepended fpath (with comment) to $rc_file"
+        fi
+    fi
+
+    # Ensure compinit is present; if it's missing, append it (after fpath)
+    if ! grep -q "autoload.*compinit" "$rc_file" 2>/dev/null; then
+        echo "" >> "$rc_file"
+        echo "# Added by my-unicorn: enable shell completion" >> "$rc_file"
+        echo "autoload -Uz compinit && compinit" >> "$rc_file"
+        echo "Added compinit to $rc_file"
+    else
+        echo "compinit already configured in $rc_file"
+    fi
+}
+
+# Function to detect shell and install appropriate completion
+install_completion() {
+    local shell_name
+    shell_name=$(basename "$SHELL")
+    
+    case "$shell_name" in
+        bash)
+            install_bash_completion
+            ;;
+        zsh)
+            install_zsh_completion
+            ;;
+        *)
+            echo "Unsupported shell: $shell_name"
+            echo "Supported shells: bash, zsh"
+            echo "You can manually install completion by following the instructions in README.md"
+            exit 1
+            ;;
+    esac
+}
+
+# Main autocomplete installation function
+install_autocomplete() {
+    echo "my-unicorn Autocomplete Installation"
+    echo "========================================"
+    
+    # Check if my-unicorn is installed
+    if [[ ! -d "$INSTALL_DIR" ]]; then
+        echo "my-unicorn is not installed. Please run './install.sh install' first."
+        exit 1
+    fi
+    
+    # Check if completion files exist
+    if [[ ! -f "$INSTALL_DIR/autocomplete/bash_autocomplete" ]] || [[ ! -f "$INSTALL_DIR/autocomplete/zsh_autocomplete" ]]; then
+        echo "Completion files not found in $INSTALL_DIR/autocomplete/"
+        exit 1
+    fi
+    
+    # Check if user wants to install for specific shell
+    if [[ $# -eq 1 ]]; then
+        case "$1" in
+            bash)
+                install_bash_completion
+                ;;
+            zsh)
+                install_zsh_completion
+                ;;
+            both)
+                install_bash_completion
+                install_zsh_completion
+                ;;
+            *)
+                echo "Invalid option: $1"
+                echo "Usage: $0 autocomplete [bash|zsh|both]"
+                exit 1
+                ;;
+        esac
+    else
+        # Auto-detect and install for current shell
+        install_completion
+    fi
+    
+    echo ""
+    echo "Installation complete!"
+
+    # Notify user to restart shell or source rc files
+    if [[ "$(basename "$SHELL")" == "zsh" ]]; then
+        local zshrc
+        zshrc=$(determine_zsh_config_dir)/.zshrc
+        echo "Please restart your shell or run 'source \"$zshrc\"' to enable autocompletion."
+    elif [[ "$(basename "$SHELL")" == "bash" ]]; then
+        echo "Please restart your shell or run 'source ~/.bashrc' to enable autocompletion."
+    else
+        echo "Please restart your shell or source the appropriate rc file to enable autocompletion."
+    fi 
+    echo ""
+    echo "Test completion by typing: my-unicorn <TAB>"
+}
+
 # -- Entry point -------------------------------------------------------------
 case "${1-}" in
   install|"") install_my_unicorn ;;
   update) update_my_unicorn ;;
+  autocomplete) 
+  shift
+  install_autocomplete "$@" 
+  ;;
   *)
     cat <<EOF
-Usage: $(basename "$0") [install|update]
+Usage: $(basename "$0") [install|update|autocomplete]
 
   install   Copy source, setup venv, install wrapper, configure PATH
   update    setup venv
+  autocomplete   Install shell completion [bash|zsh|both]
+
+Examples:
+  $(basename "$0") install            # Full installation
+  $(basename "$0") update             # Update virtual environment
+  $(basename "$0") autocomplete       # Install completion for current shell
+  $(basename "$0") autocomplete bash  # Install bash completion
+  $(basename "$0") autocomplete zsh   # Install zsh completion
+  $(basename "$0") autocomplete both  # Install both bash and zsh completion
 EOF
     exit 1
     ;;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'my-unicorn'
-version = '1.7.0-alpha'
+version = '1.7.1-alpha'
 maintainers = [{ name = "Cyber-Syntax" }]
 license = { text = "GPL-3.0-or-later" }
 description = 'My Unicorn is a command-line tool to manage AppImages on Linux. It allows users to install, update, and manage AppImages from GitHub repositories easily. It is designed to simplify the process of handling AppImages, making it more convenient for users to keep their applications up-to-date.'
@@ -60,6 +60,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["my_unicorn*"]
+exclude = ["autocomplete*", "tests*", "scripts*", "docs*", "examples*"]
 
 [tool.coverage.paths]
 source = ["my_unicorn"]


### PR DESCRIPTION
Introduce a new feature that allows users to install autocomplete for the my-unicorn command in bash and zsh shells. Update the version to 1.7.1-alpha and document the changes in the README.