### PR TITLE
fix: use echo instead old print_warning function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.7.2-alpha
 ## v1.7.1-alpha
 ## v1.7.0-alpha
 # CHANGES

--- a/my-unicorn-installer.sh
+++ b/my-unicorn-installer.sh
@@ -201,7 +201,7 @@ install_bash_completion() {
         echo "source \"$bash_autocomplete_src\"" >> ~/.bashrc
         echo "Bash completion added to ~/.bashrc"
     else
-        print_warning "Bash completion already exists in ~/.bashrc"
+        echo "Bash completion already exists in ~/.bashrc"
     fi
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'my-unicorn'
-version = '1.7.1-alpha'
+version = '1.7.2-alpha'
 maintainers = [{ name = "Cyber-Syntax" }]
 license = { text = "GPL-3.0-or-later" }
 description = 'My Unicorn is a command-line tool to manage AppImages on Linux. It allows users to install, update, and manage AppImages from GitHub repositories easily. It is designed to simplify the process of handling AppImages, making it more convenient for users to keep their applications up-to-date.'


### PR DESCRIPTION
Replace the deprecated print_warning function with echo to improve code consistency and clarity. Update version number to 1.7.2-alpha in the project configuration.