### PR TITLE
Add --version command to CLI for version display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.7.4-alpha
 ## v1.7.3-alpha
 ## v1.7.2-alpha
 ## v1.7.1-alpha

--- a/my_unicorn/__init__.py
+++ b/my_unicorn/__init__.py
@@ -1,5 +1,15 @@
-# __init__.py
-# The toplevel my-unicorn package.
-#
-# Copyright (C) 2023 - 2025 Cyber-Syntax
-#
+"""Top-level package for my-unicorn.
+
+This module exposes the package version so the CLI and other
+components can display it. Keep this in sync with the project
+version in ``pyproject.toml``.
+
+Author: 2023 - 2025 Cyber-Syntax
+License: GPL-3.0
+"""
+
+# NOTE: A future improvement could be to read this from package metadata when
+# installed, but a static value is simpler and reliable for development.
+__version__ = "1.7.4-alpha"
+
+__all__ = ["__version__"]

--- a/my_unicorn/cli/runner.py
+++ b/my_unicorn/cli/runner.py
@@ -7,6 +7,7 @@ parsed arguments to the appropriate command handlers.
 import sys
 from argparse import Namespace
 
+from .. import __version__
 from ..auth import auth_manager
 from ..commands.auth import AuthHandler
 from ..commands.backup import BackupHandler
@@ -81,6 +82,11 @@ class CLIRunner:
             # Parse command-line arguments
             parser = CLIParser(self.global_config)
             args = parser.parse_args()
+
+            # Global: --version should print package version and exit early.
+            if getattr(args, "version", False):
+                print(__version__)
+                return
 
             # Validate command
             if not args.command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'my-unicorn'
-version = '1.7.3-alpha'
+version = '1.7.4-alpha'
 maintainers = [{ name = "Cyber-Syntax" }]
 license = { text = "GPL-3.0-or-later" }
 description = 'My Unicorn is a command-line tool to manage AppImages on Linux. It allows users to install, update, and manage AppImages from GitHub repositories easily. It is designed to simplify the process of handling AppImages, making it more convenient for users to keep their applications up-to-date.'

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,56 @@
+"""Tests for the CLI --version flag behavior."""
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from my_unicorn import __version__
+from my_unicorn.cli.runner import CLIRunner
+
+
+@pytest.mark.asyncio
+async def test_version_flag_prints_version_and_exits(monkeypatch, capsys):
+    """When --version is passed, the CLI should print the package version and return early."""
+    monkeypatch.setattr(
+        "my_unicorn.cli.parser.CLIParser.parse_args",
+        lambda self: SimpleNamespace(version=True),
+    )
+
+    runner = CLIRunner()
+    await runner.run()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == __version__
+
+
+@pytest.mark.asyncio
+async def test_version_flag_works_even_with_command_present(monkeypatch, capsys):
+    """If version is True and command is also set, version should still take precedence."""
+    monkeypatch.setattr(
+        "my_unicorn.cli.parser.CLIParser.parse_args",
+        lambda self: SimpleNamespace(version=True, command="install"),
+    )
+
+    runner = CLIRunner()
+    await runner.run()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == __version__
+
+
+def test_cli_version_integration_subprocess():
+    """Run the entrypoint as a subprocess to verify end-to-end wiring."""
+    # Repository root (one parent up from tests/ file)
+    repo_root = Path(__file__).resolve().parents[1]
+
+    p = subprocess.run(
+        [sys.executable, "run.py", "--version"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert p.returncode == 0
+    assert p.stdout.strip() == __version__


### PR DESCRIPTION
Introduce a new command-line option to display the package version. Update the version in the project metadata and add tests to ensure the functionality works as intended.