### PR TITLE
fix(backup): update restore process to load raw app config for catalog_ref issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1-alpha] - 2026-04-24
+
+### Fixed
+
+- Fixed SchemaValidationError; Missing required field 'catalog_ref' #241 by changing the load_app_config function to load_raw_app_config function.
+
 ## [2.4.0-alpha] - 2026-03-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'my-unicorn'
-version = '2.4.0-alpha'
+version = '2.4.1-alpha'
 license = { text = "GPL-3.0-or-later" }
 description = 'My Unicorn is a command-line tool to manage AppImages on Linux. It allows users to install, update, and manage AppImages from GitHub repositories easily. It is designed to simplify the process of handling AppImages, making it more convenient for users to keep their applications up-to-date.'
 keywords = ["appimage", "appimage-manager"]

--- a/src/my_unicorn/core/backup/restore.py
+++ b/src/my_unicorn/core/backup/restore.py
@@ -304,7 +304,7 @@ def _load_and_check_app_config(
         App configuration or None if validation fails
 
     """
-    app_config = config_manager.load_app_config(app_name)
+    app_config = config_manager.load_raw_app_config(app_name)
     if not app_config:
         logger.error("App configuration not found for %s", app_name)
         return None

--- a/tests/cli/commands/backup/test_backup_restore.py
+++ b/tests/cli/commands/backup/test_backup_restore.py
@@ -39,6 +39,7 @@ class TestBackupHandler:
 
         # Mock config manager
         mock_config_manager.load_app_config.return_value = sample_app_config
+        mock_config_manager.load_raw_app_config.return_value = sample_app_config
 
         args = MagicMock()
         args.app_name = app_name
@@ -87,6 +88,7 @@ class TestBackupHandler:
         )
 
         mock_config_manager.load_app_config.return_value = sample_app_config
+        mock_config_manager.load_raw_app_config.return_value = sample_app_config
 
         args = MagicMock()
         args.app_name = app_name
@@ -144,6 +146,7 @@ class TestBackupHandler:
         )
 
         mock_config_manager.load_app_config.return_value = current_config
+        mock_config_manager.load_raw_app_config.return_value = sample_app_config
 
         args = MagicMock()
         args.app_name = app_name

--- a/tests/core/backup/test_restore.py
+++ b/tests/core/backup/test_restore.py
@@ -19,7 +19,7 @@ class TestBackupServiceRestore:
     ) -> None:
         """Test restoring the latest backup."""
         config_manager, _, backup_dir, storage_dir = dummy_config
-        config_manager.load_app_config.return_value = sample_app_config
+        config_manager.load_raw_app_config.return_value = sample_app_config
 
         app_name = "app1"
         app_backup_dir = backup_dir / app_name
@@ -52,7 +52,7 @@ class TestBackupServiceRestore:
     ) -> None:
         """Test that current version is backed up before restore."""
         config_manager, _, backup_dir, storage_dir = dummy_config
-        config_manager.load_app_config.return_value = sample_app_config
+        config_manager.load_raw_app_config.return_value = sample_app_config
 
         app_name = "app1"
 
@@ -89,7 +89,7 @@ class TestBackupServiceRestore:
     ) -> None:
         """Test restore when app config is missing."""
         config_manager, _, _, storage_dir = dummy_config
-        config_manager.load_app_config.return_value = None
+        config_manager.load_raw_app_config.return_value = None
 
         result = backup_service.restore_latest_backup(
             "nonexistent", storage_dir
@@ -104,7 +104,7 @@ class TestBackupServiceRestore:
     ) -> None:
         """Test restore when backup integrity check fails."""
         config_manager, _, backup_dir, storage_dir = dummy_config
-        config_manager.load_app_config.return_value = sample_app_config
+        config_manager.load_raw_app_config.return_value = sample_app_config
 
         app_name = "app1"
         app_backup_dir = backup_dir / app_name
@@ -137,7 +137,7 @@ class TestBackupServiceRestore:
         config_manager, _, backup_dir, storage_dir = dummy_config
 
         # Use v1 config fixture
-        config_manager.load_app_config.return_value = sample_v1_app_config
+        config_manager.load_raw_app_config.return_value = sample_v1_app_config
 
         app_name = "app1"
         app_backup_dir = backup_dir / app_name
@@ -172,7 +172,7 @@ class TestBackupServiceRestore:
 
         # Configure max_backup=2 to trigger cleanup
         global_config["max_backup"] = 2
-        config_manager.load_app_config.return_value = sample_app_config
+        config_manager.load_raw_app_config.return_value = sample_app_config
 
         app_name = "app1"
         app_backup_dir = backup_dir / app_name
@@ -244,7 +244,7 @@ class TestRestoreBackupValidation:
         - Or explicitly skip_validation=False
         """
         config_manager, _, backup_dir, storage_dir = dummy_config
-        config_manager.load_app_config.return_value = sample_app_config
+        config_manager.load_raw_app_config.return_value = sample_app_config
 
         app_name = "app1"
         app_backup_dir = backup_dir / app_name

--- a/uv.lock
+++ b/uv.lock
@@ -800,7 +800,7 @@ wheels = [
 
 [[package]]
 name = "my-unicorn"
-version = "2.4.0a0"
+version = "2.4.1a0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Resolve SchemaValidationError by using `load_raw_app_config` during backup restore. This change ensures that the required `catalog_ref` field is properly included in the app configuration after restoration. Version bumped to 2.4.1-alpha to reflect this fix.

Fixes #241