### PR TITLE
fix(cli): prevent unexpected keyword error during self-upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.4.2-alpha] - 2026-04-24
+## [2.4.3-alpha] - 2026-04-28
+
+### Fixed
+
+- Fixed upgrade unexpected keyword argument error.
+
+## [2.4.2-alpha] - 2026-04-27
 
 ### Changed
 
@@ -35,7 +41,7 @@ Updated types-pyyaml v6.0.12.20250915 -> v6.0.12.20260408
 
 - Fixed a orphaned metadata issue in the backup service where metadata entries were not being removed when the backup file was already gone, leading to orphaned metadata entries.
 
-## [2.4.1-alpha] - 2026-04-24
+## [2.4.1-alpha] - 2026-04-27
 
 ### Fixed
 

--- a/src/my_unicorn/cli/upgrade.py
+++ b/src/my_unicorn/cli/upgrade.py
@@ -208,10 +208,10 @@ async def _fetch_latest_prerelease_version() -> str | None:
 
     async with aiohttp.ClientSession() as session:
         fetcher = ReleaseFetcher(
-            GITHUB_OWNER,
-            GITHUB_REPO,
-            session,
-            use_cache=False,
+            owner=GITHUB_OWNER,
+            repo=GITHUB_REPO,
+            session=session,
+            cache_manager=None,
         )
         try:
             release = await fetcher.fetch_latest_prerelease(ignore_cache=True)

--- a/tests/cli/test_upgrade.py
+++ b/tests/cli/test_upgrade.py
@@ -1,9 +1,11 @@
 """Unit tests for self-update helpers and upgrade flow."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import my_unicorn.cli.upgrade as upgrade_module
 from my_unicorn.cli.upgrade import (
     check_for_self_update,
     perform_self_update,
@@ -167,3 +169,40 @@ async def test_dev_installation_upgrade_same_version() -> None:
         # Dev installation should always upgrade to production
         assert should_upgrade is True
         assert latest_version == "2.0.0"
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_prerelease_version_disables_cache() -> None:
+    """Self-upgrade version check bypasses and disables caching."""
+
+    session_cm = AsyncMock()
+    session = AsyncMock()
+    session_cm.__aenter__.return_value = session
+    session_cm.__aexit__.return_value = False
+
+    release = SimpleNamespace(version="2.0.1", original_tag_name="v2.0.1")
+
+    with (
+        patch(
+            "my_unicorn.cli.upgrade.aiohttp.ClientSession",
+            return_value=session_cm,
+        ),
+        patch("my_unicorn.cli.upgrade.ReleaseFetcher") as mock_fetcher_cls,
+    ):
+        mock_fetcher_instance = mock_fetcher_cls.return_value
+        mock_fetcher_instance.fetch_latest_prerelease = AsyncMock(
+            return_value=release
+        )
+
+        latest = await upgrade_module._fetch_latest_prerelease_version()
+
+        assert latest == "2.0.1"
+        mock_fetcher_cls.assert_called_once_with(
+            owner="Cyber-Syntax",
+            repo="my-unicorn",
+            session=session,
+            cache_manager=None,
+        )
+        mock_fetcher_instance.fetch_latest_prerelease.assert_awaited_once_with(
+            ignore_cache=True
+        )


### PR DESCRIPTION
Explicitly disable caching for the CLI self-upgrade process to prevent unexpected keyword argument errors. Added a test to ensure that the prerelease fetch ignores cache.


## Type of Change
- [x] Bug fix


## Checklist

- [ ] I have included relevant changes to the documentation
- [x] I have run `uv run pytest` and `uv run pytest tests/e2e/` to ensure that my changes do not break existing tests
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass

