### PR TITLE
fix(update.bash): drop spurious 'All outdated apps updated successfully' (#291)

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -150,7 +150,6 @@ nuclear                   ❌ Update failed
 
 🎉 Successfully updated 1 app(s)
 ❌ 1 app(s) failed to update
-✓ All outdated apps updated successfully
 ```
 
 ## Remove Examples

--- a/scripts/update.bash
+++ b/scripts/update.bash
@@ -176,15 +176,17 @@ update_outdated() {
 
   echo "Updating ${#outdated_apps[@]} outdated app(s): ${outdated_apps[*]}"
 
-  # Update all outdated apps concurrently in a single command
+  # Update all outdated apps concurrently. The inner command already
+  # prints its own structured summary (per-app ✅/❌ lines + a count
+  # of failures). Don't print our own "all updated successfully"
+  # message here — `my-unicorn update` exits 0 even when some apps
+  # failed (e.g. the AppImage wasn't published yet), so an
+  # unconditional echo would contradict the per-app errors above.
+  # See Cyber-Syntax/my-unicorn#291.
   if ! "$UNICORN" update "${outdated_apps[@]}"; then
     echo "Error: Update failed for some apps. Check your network connection or logs."
     return 1
   fi
-
-
-
-  echo "✓ All outdated apps updated successfully"
 }
 
 # help for CLI


### PR DESCRIPTION
Closes #291.

## Reproduction (from the issue)
```
Updating 1 outdated app(s): tagspaces
Fetching from API:
GitHub Releases      1/1 Retrieved from cache

📦 Update Summary:
--------------------------------------------------
tagspaces                 ❌ Update failed
                             → AppImage not found in release - may still be building

❌ 1 app(s) failed to update
19:11:42 - my_unicorn.core.update.context - ERROR - No AppImage found for tagspaces
✓ All outdated apps updated successfully       ← contradiction
```

## Root cause
The wrapper script in \`scripts/update.bash\` prints \`✓ All outdated apps updated successfully\` whenever \`my-unicorn update\` returns 0. But the inner command exits 0 even when individual apps failed (e.g. AppImage not yet published) — partial failures are tracked in the structured summary, not the exit code. So the wrapper's success line directly contradicts the per-app ❌ rows.

## Fix
Per the issue's suggestion (\"remove success from script and let my-unicorn show success or errors\"), drop the unconditional echo. The inner command already prints its own per-app + aggregate summary (\`🎉 Successfully updated N app(s)\` / \`❌ N app(s) failed to update\`), so users see exactly what happened with no contradictory wrapper line.

The non-zero exit branch (real infra failure: network, etc.) keeps its existing \`Error: Update failed for some apps\` line so a hard failure isn't silent either.

Also strip the matching example from \`docs/ui.md\` so the docs no longer show the contradictory pair.

## Test plan
- [x] Bash syntax check (\`bash -n scripts/update.bash\`) clean.
- [x] No production code paths changed — only the wrapper-level echo and the matching example in the user-facing docs.
- [x] If \`my-unicorn update\` returns non-zero (true infra failure), the existing \`Error: Update failed for some apps\` branch still fires.