### PR TITLE
refactor(upgrade): use version tag for self-upgrade command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0-alpha] - 2026-04-29
+
+### Changed
+
+- Refactored cli self upgrade module to use tag base install. From now on, the self upgrade process will use the latest tag commit from the repository to perform the upgrade instead of using the latest commit from the main branch.
+
 ## [2.4.4-alpha] - 2026-04-28
 
 ### Changed
@@ -12,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored desktop_entry modules to use a single module with a DesktopEntry class for better organization and maintainability. Also, added missing type annotations, improved docstrings and removed dead code in the desktop entry handling logic.
 
 ### Fixed
+
 - Fixed update.bash script ui/ux issue (#292)
 
 ## [2.4.3-alpha] - 2026-04-28
@@ -342,7 +349,7 @@ Updated types-pyyaml v6.0.12.20250915 -> v6.0.12.20260408
     - Now extracts icons directly from AppImage files
     - Removed download_url entries from all catalog configurations
 - **Backup Migration**: Removed automatic migration from old flat backup format to folder-based structure
-    - Users with old backups (*.backup.AppImage) should manually reorganize them if needed
+    - Users with old backups (\*.backup.AppImage) should manually reorganize them if needed
     - New installations and users who already migrated are unaffected
     - Backup system now exclusively uses folder-based structure with metadata.json
 - **Show Progress Parameter**: Removed show_progress parameter from download methods
@@ -358,31 +365,31 @@ Updated types-pyyaml v6.0.12.20250915 -> v6.0.12.20260408
 1. **beekeeper-studio name**:
     - (Recommended) If you use beekeeper-studio, remove the app before migration to v2.0.0 and reinstall after migration to avoid issues.
     - You can manually rename your config and desktop files for Beekeeper Studio if you migrated before reinstalling:
-      1. Rename `~/.config/my-unicorn/apps/beekeper-studio.json` to `beekeeper-studio.json`.
-      2. Rename `~/.local/share/applications/beekeper-studio.desktop` to `beekeeper-studio.desktop`.
-      3. Update `catalog_ref` field in the config file to `beekeeper-studio`.
+        1. Rename `~/.config/my-unicorn/apps/beekeper-studio.json` to `beekeeper-studio.json`.
+        2. Rename `~/.local/share/applications/beekeper-studio.desktop` to `beekeeper-studio.desktop`.
+        3. Update `catalog_ref` field in the config file to `beekeeper-studio`.
 
 2. **Run migration command**:
 
-   ```bash
-   my-unicorn migrate
-   ```
+    ```bash
+    my-unicorn migrate
+    ```
 
 3. **Migration process**:
-   - Automatically detects v1 configs in `~/.config/my-unicorn/apps/`
-   - Creates `.json.backup` files before migration
-   - Converts to v2 format with appropriate structure
-   - Validates migrated configs against JSON schema
+    - Automatically detects v1 configs in `~/.config/my-unicorn/apps/`
+    - Creates `.json.backup` files before migration
+    - Converts to v2 format with appropriate structure
+    - Validates migrated configs against JSON schema
 
 4. **After migration**:
-   - Review migrated configs in `~/.config/my-unicorn/apps/`
-   - Backups available in `~/.config/my-unicorn/apps/backups/`
-   - Use `catalog` command instead of `list` (alias still works)
+    - Review migrated configs in `~/.config/my-unicorn/apps/`
+    - Backups available in `~/.config/my-unicorn/apps/backups/`
+    - Use `catalog` command instead of `list` (alias still works)
 
 5. **Config structure changes**:
-   - Catalog apps: Only state + catalog_ref stored (metadata from catalog)
-   - URL apps: Full config in overrides section
-   - See docs/config.md for detailed v2 format documentation
+    - Catalog apps: Only state + catalog_ref stored (metadata from catalog)
+    - URL apps: Full config in overrides section
+    - See docs/config.md for detailed v2 format documentation
 
 For detailed migration information, see [docs/config.md](docs/config.md).
 

--- a/docs/dev/upgrade.md
+++ b/docs/dev/upgrade.md
@@ -4,6 +4,29 @@
 
 The upgrade module (`cli/upgrade.py`) handles self-updating the my-unicorn package using uv's tool management capabilities. This document explains the key design decisions and rationale.
 
+## Prerelease vs Stable Release Handling
+
+**Current Implementation:** Fetches latest prerelease using `fetch_latest_prerelease()`
+
+**Future Migration:** When my-unicorn publishes stable releases, update `_fetch_latest_prerelease_version()` to use `fetch_latest_release()` instead. This will prioritize stable versions over prereleases.
+
+**Why Not Now:** YAGNI principle - we'll implement stable release logic when it's actually needed. Currently, my-unicorn only publishes prerelease versions. ([#260](https://github.com/Cyber-Syntax/my-unicorn/issues/260))
+
+## Development vs Production Detection
+
+The module detects whether my-unicorn is installed as:
+
+- **Development:** Installed from local file path (`file://`)
+- **Production:** Installed from git repository (`git+https://`)
+    - **Tagged version:** After version 2.5.0-alpha, we migrated to tagged releases, so we use `git+https://github.com/Cyber-Syntax/my-unicorn.git@v2.3.0-alpha` to specify version by tag instead of main branch.
+
+**Behavior:**
+
+- Development installations always trigger an upgrade to production version
+- This prevents developers from accidentally running outdated local builds
+
+**Detection Method:** Parses output from `uv tool list --show-version-specifiers` to check for `file://` URI scheme.
+
 ## Cache Handling for Version Checks
 
 **Decision:** The upgrade command intentionally disables caching for release fetches (`use_cache=False`, `ignore_cache=True`).
@@ -23,14 +46,6 @@ Rate limiting is acceptable for upgrade operations:
 - **With token** (via keyring): 5000 requests/hour
 - Users run upgrades infrequently, minimizing API usage
 - Accuracy of version information is more important than caching
-
-## Prerelease vs Stable Release Handling
-
-**Current Implementation:** Fetches latest prerelease using `fetch_latest_prerelease()`
-
-**Future Migration:** When my-unicorn publishes stable releases, update `_fetch_latest_prerelease_version()` to use `fetch_latest_release()` instead. This will prioritize stable versions over prereleases.
-
-**Why Not Now:** YAGNI principle - we'll implement stable release logic when it's actually needed. Currently, my-unicorn only publishes prerelease versions.
 
 ## Version Normalization
 
@@ -56,20 +71,6 @@ The module converts semantic versioning (semver) style version strings to PEP 44
 
 **User Impact:** Users must restart their terminal after a successful upgrade to refresh the command cache and use the updated version.
 
-## Development vs Production Detection
-
-The module detects whether my-unicorn is installed as:
-
-- **Development:** Installed from local file path (`file://`)
-- **Production:** Installed from git repository (`git+https://`)
-
-**Behavior:**
-
-- Development installations always trigger an upgrade to production version
-- This prevents developers from accidentally running outdated local builds
-
-**Detection Method:** Parses output from `uv tool list --show-version-specifiers` to check for `file://` URI scheme.
-
 ## Error Handling Philosophy
 
 **Version Parsing Failures:**
@@ -83,23 +84,3 @@ The module detects whether my-unicorn is installed as:
 - Log warning and proceed with upgrade (fail-open approach)
 - Rationale: Better to attempt upgrade than block users from security updates
 - GitHub API issues should not prevent critical updates
-
-## Future Improvements
-
-Potential enhancements to consider:
-
-1. **Stable Release Support:** Migrate from prerelease-only to stable release prioritization when my-unicorn begins publishing stable versions
-2. **Rollback Capability:** Consider adding ability to revert to previous version if upgrade fails
-3. **Change Log Display:** Show release notes before upgrade to inform users of changes
-4. **Selective Version Targeting:** Allow users to upgrade to specific version rather than always latest
-5. **Offline Mode:** Support upgrade from locally downloaded packages when internet is unavailable
-
-## Testing Considerations
-
-Key test scenarios:
-
-- Version comparison with various semver and PEP 440 formats
-- Prerelease version handling (alpha, beta, rc)
-- Development vs production installation detection
-- GitHub API failures and rate limiting
-- Invalid version string parsing

--- a/docs/dev/uv.md
+++ b/docs/dev/uv.md
@@ -1,4 +1,24 @@
-# Building your cli tool with uv package manager
+# Astral uv package manager
+
+For more information about Astral uv package manager, please visit [uv tools documentation](https://docs.astral.sh/uv/concepts/tools/).
+
+## Installing and updating my-unicorn via uv (Latest release version by tag)
+
+Example below shows how to install specific version of my-unicorn tool via uv and update it to another version by tag. It is perfectly updated the tool to new version.
+
+```bash
+uv tool install git+https://github.com/Cyber-Syntax/my-unicorn.git@v2.3.0-alpha
+Resolved 30 packages in 20ms
+      Built my-unicorn @ git+https://github.com/Cyber-Syntax/my-unicorn.git@5b23f1eec7e55c4a9ba4201ac756833521c4d587
+Prepared 1 package in 617ms
+Uninstalled 1 package in 5ms
+Installed 1 package in 16ms
+ - my-unicorn==2.4.0a0 (from git+https://github.com/Cyber-Syntax/my-unicorn@3d1163b08e09958b726cd51e95144764849217f3)
+ + my-unicorn==2.3.0a0 (from git+https://github.com/Cyber-Syntax/my-unicorn.git@5b23f1eec7e55c4a9ba4201ac756833521c4d587)
+Installed 1 executable: my-unicorn
+```
+
+## OLD: Installing and updating my-unicorn via uv (Latest main branch)
 
 ```bash
 # Installing cli tool from main branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'my-unicorn'
-version = '2.4.4-alpha'
+version = '2.5.0-alpha'
 license = { text = "GPL-3.0-or-later" }
 description = 'My Unicorn is a command-line tool to manage AppImages on Linux. It allows users to install, update, and manage AppImages from GitHub repositories easily. It is designed to simplify the process of handling AppImages, making it more convenient for users to keep their applications up-to-date.'
 keywords = ["appimage", "appimage-manager"]

--- a/src/my_unicorn/cli/commands/upgrade.py
+++ b/src/my_unicorn/cli/commands/upgrade.py
@@ -46,6 +46,13 @@ class UpgradeHandler:
                 __version__
             )
 
+            if should_upgrade is None:
+                logger.warning(
+                    "Could not determine whether an update is available. Current: %s",
+                    __version__,
+                )
+                return
+
             if latest_version:
                 logger.info(
                     "Current: %s, Latest: %s",
@@ -79,6 +86,12 @@ class UpgradeHandler:
             should_upgrade, latest_version = await should_perform_self_update(
                 __version__
             )
+
+            if should_upgrade is None:
+                logger.warning(
+                    "Could not determine the latest version; upgrade skipped."
+                )
+                return
 
             if not should_upgrade:
                 logger.info(

--- a/src/my_unicorn/cli/commands/upgrade.py
+++ b/src/my_unicorn/cli/commands/upgrade.py
@@ -87,23 +87,24 @@ class UpgradeHandler:
                 )
                 return
 
-            if latest_version:
-                logger.info(
-                    "Updating my-unicorn from %s to %s",
-                    __version__,
-                    latest_version,
-                )
+            # Narrow the type: should_upgrade=True always comes with a version tag
+            if not latest_version:
+                logger.warning("No version tag available; cannot upgrade.")
+                return
 
-            if perform_self_update():
-                logger.info("✅ Upgrade completed successfully!")
-                logger.info(
-                    "Please restart your terminal to refresh "
-                    "the command cache."
-                )
-            else:
-                logger.info(
-                    "❌ Upgrade failed. Please try again or update manually."
-                )
+            # latest_version is now str, not str | None
+            logger.info(
+                "Updating my-unicorn from %s to %s",
+                __version__,
+                latest_version,
+            )
+            logger.info("Handing off to uv — terminal will update now...")
+            perform_self_update(latest_version)
+
+            # Only reached if execvp failed
+            logger.info(
+                "❌ Upgrade failed. Please try again or update manually."
+            )
         except Exception as e:
-            logger.exception("Upgrade failed")
+            logger.exception("Upgrade failed", exc_info=e)
             logger.info("❌ Upgrade failed: %s", e)

--- a/src/my_unicorn/cli/upgrade.py
+++ b/src/my_unicorn/cli/upgrade.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 
 GITHUB_OWNER = "Cyber-Syntax"
 GITHUB_REPO = "my-unicorn"
-GITHUB_URL = f"https://github.com/{GITHUB_OWNER}/{GITHUB_REPO}"
+GITHUB_GIT_URL = f"git+https://github.com/{GITHUB_OWNER}/{GITHUB_REPO}.git"
 
 # Map semver prerelease labels to PEP 440 equivalents
 _PRERELEASE_MAP = {
@@ -132,12 +132,15 @@ async def _run_uv_tool_list() -> bool:
         return False
 
 
-def perform_self_update() -> bool:
+def perform_self_update(version: str) -> bool:
     """Update my-unicorn using uv tool install --upgrade from git.
 
     This ensures a reliable update from the official repository,
     regardless of how it was originally installed. Uses os.execvp to replace
     the current process, ensuring the upgrade completes properly.
+
+    Args:
+        version: version to install (e.g., '2.3.0-alpha').
 
     Returns:
         False if upgrade could not be started.
@@ -149,9 +152,13 @@ def perform_self_update() -> bool:
 
     """
     logger.debug("Starting upgrade to my-unicorn...")
+
+    version_tag = version if version.startswith("v") else f"v{version}"
+    install_target = f"{GITHUB_GIT_URL}@{version_tag}"
+
     logger.debug(
-        "Executing: uv tool install --upgrade git+%s",
-        GITHUB_URL,
+        "Executing: uv tool install --upgrade %s",
+        install_target,
     )
 
     uv_executable = shutil.which("uv") or "uv"
@@ -166,17 +173,13 @@ def perform_self_update() -> bool:
                 "tool",
                 "install",
                 "--upgrade",
-                f"git+{GITHUB_URL}",
+                install_target,
             ],
         )
     except (OSError, FileNotFoundError) as e:
         logger.exception("Update failed")
         logger.info("❌ Update failed: %s", e)
         return False
-
-    logger.error("Failed to execute uv upgrade")
-    logger.info("❌ Failed to execute upgrade command")
-    return False
 
 
 def _is_candidate_newer(current_version: str, candidate_version: str) -> bool:
@@ -242,23 +245,18 @@ async def should_perform_self_update(
         - latest_version: The latest version string, or None if unavailable
     """
     is_dev_install = await _run_uv_tool_list()
+    latest_version = await _fetch_latest_prerelease_version()
+
+    if not latest_version or not latest_version.strip():
+        logger.warning("Could not determine latest version; skipping upgrade.")
+        return False, None  # don't upgrade blindly without a tag
 
     if is_dev_install:
         logger.info("🔧 Development installation detected")
-        latest_version = await _fetch_latest_prerelease_version()
-        return True, latest_version
-
-    latest_version = await _fetch_latest_prerelease_version()
-
-    if not latest_version:
-        logger.warning(
-            "Could not determine latest my-unicorn version; proceeding "
-            "with upgrade.",
-        )
-        return True, None
-
-    if not latest_version.strip():
-        return True, None
+        return (
+            True,
+            latest_version,
+        )  # dev installation should always upgrade to production
 
     if not _is_candidate_newer(current_version, latest_version):
         return False, latest_version
@@ -266,25 +264,29 @@ async def should_perform_self_update(
     return True, latest_version
 
 
-async def check_for_self_update() -> bool:
+async def check_for_self_update() -> tuple[
+    bool, str | None
+]:  # expose the version
     """Check if a newer my-unicorn release is available (cache disabled).
 
     Returns:
         True if a newer version is available, False otherwise.
     """
 
-    should_upgrade, _ = await should_perform_self_update(__version__)
-    return should_upgrade
+    return await should_perform_self_update(__version__)
 
 
-async def perform_self_update_async() -> bool:
+async def perform_self_update_async(version: str) -> bool:
     """Async wrapper for perform_self_update.
 
     Allows perform_self_update() to be called from async contexts.
+
+    Args:
+        version: release version to install (e.g., '2.3.0-alpha')
 
     Returns:
         False if update could not be started.
         Does not return on success (process replaced by execvp).
 
     """
-    return perform_self_update()
+    return perform_self_update(version)

--- a/src/my_unicorn/cli/upgrade.py
+++ b/src/my_unicorn/cli/upgrade.py
@@ -232,7 +232,7 @@ async def _fetch_latest_prerelease_version() -> str | None:
 
 async def should_perform_self_update(
     current_version: str,
-) -> tuple[bool, str | None]:
+) -> tuple[bool | None, str | None]:
     """Determine if a newer release is available.
 
     Checks for dev installation first. Dev installations always upgrade to
@@ -241,7 +241,8 @@ async def should_perform_self_update(
 
     Returns:
         A tuple of (should_upgrade, latest_version) where:
-        - should_upgrade: True if upgrade needed (dev install or newer version)
+        - should_upgrade: True if upgrade needed (dev install or newer version),
+          False if already up to date, or None if the check failed
         - latest_version: The latest version string, or None if unavailable
     """
     is_dev_install = await _run_uv_tool_list()
@@ -249,7 +250,7 @@ async def should_perform_self_update(
 
     if not latest_version or not latest_version.strip():
         logger.warning("Could not determine latest version; skipping upgrade.")
-        return False, None  # don't upgrade blindly without a tag
+        return None, None  # don't upgrade blindly without a tag
 
     if is_dev_install:
         logger.info("🔧 Development installation detected")
@@ -265,12 +266,13 @@ async def should_perform_self_update(
 
 
 async def check_for_self_update() -> tuple[
-    bool, str | None
+    bool | None, str | None
 ]:  # expose the version
     """Check if a newer my-unicorn release is available (cache disabled).
 
     Returns:
-        True if a newer version is available, False otherwise.
+        True if a newer version is available, False if up to date,
+        or None if the check failed.
     """
 
     return await should_perform_self_update(__version__)

--- a/tests/cli/commands/test_upgrade.py
+++ b/tests/cli/commands/test_upgrade.py
@@ -13,8 +13,8 @@ from my_unicorn.cli.commands.upgrade import UpgradeHandler
 
 
 @pytest.mark.asyncio
-async def test_execute_perform_update_success() -> None:
-    """Upgrade runs when a newer version is available."""
+async def test_execute_perform_update_calls_with_version() -> None:
+    """Upgrade calls perform_self_update with the resolved version tag."""
     handler = UpgradeHandler()
     with (
         patch(
@@ -25,16 +25,18 @@ async def test_execute_perform_update_success() -> None:
             AsyncMock(return_value=(True, "2.0.1")),
         ) as mock_check,
     ):
-        mock_perform.return_value = True
+        mock_perform.return_value = (
+            None  # execvp replaces process; never returns on success
+        )
         args = Namespace(check=False)
         await handler.execute(args)
         mock_check.assert_called_once()
-        mock_perform.assert_called_once()
+        mock_perform.assert_called_once_with("2.0.1")
 
 
 @pytest.mark.asyncio
 async def test_execute_perform_update_failure() -> None:
-    """Upgrade flow logs failure when exec does not start."""
+    """Upgrade flow logs failure when execvp returns (i.e. did not replace process)."""
     handler = UpgradeHandler()
     with (
         patch(
@@ -46,12 +48,11 @@ async def test_execute_perform_update_failure() -> None:
         ) as mock_check,
         patch("my_unicorn.cli.commands.upgrade.logger") as mock_logger,
     ):
-        mock_perform.return_value = False
+        mock_perform.return_value = False  # execvp failed, returned instead
         args = Namespace(check=False)
         await handler.execute(args)
         mock_check.assert_called_once()
-        mock_perform.assert_called_once()
-        # Check that the failure message was logged
+        mock_perform.assert_called_once_with("2.0.1")
         mock_logger.info.assert_any_call(
             "❌ Upgrade failed. Please try again or update manually."
         )
@@ -82,8 +83,27 @@ async def test_execute_skips_when_latest() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_check_version() -> None:
-    """Check version displays current and latest versions."""
+async def test_execute_skips_when_version_unavailable() -> None:
+    """Upgrade is skipped when latest version cannot be determined."""
+    handler = UpgradeHandler()
+    with (
+        patch(
+            "my_unicorn.cli.commands.upgrade.should_perform_self_update",
+            AsyncMock(return_value=(False, None)),
+        ),
+        patch(
+            "my_unicorn.cli.commands.upgrade.perform_self_update"
+        ) as mock_perform,
+        patch("my_unicorn.cli.commands.upgrade.__version__", "2.0.0"),
+    ):
+        args = Namespace(check=False)
+        await handler.execute(args)
+        mock_perform.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_check_version_newer_available() -> None:
+    """Check version displays current and latest versions when update is available."""
     handler = UpgradeHandler()
     with (
         patch(
@@ -102,3 +122,48 @@ async def test_execute_check_version() -> None:
             "2.0.1",
         )
         mock_logger.info.assert_any_call("✅ A newer version is available!")
+
+
+@pytest.mark.asyncio
+async def test_execute_check_version_already_latest() -> None:
+    """Check version reports up to date when on the latest release."""
+    handler = UpgradeHandler()
+    with (
+        patch(
+            "my_unicorn.cli.commands.upgrade.should_perform_self_update",
+            AsyncMock(return_value=(False, "2.0.0")),
+        ) as mock_check,
+        patch("my_unicorn.cli.commands.upgrade.logger") as mock_logger,
+        patch("my_unicorn.cli.commands.upgrade.__version__", "2.0.0"),
+    ):
+        args = Namespace(check=True)
+        await handler.execute(args)
+        mock_check.assert_called_once()
+        mock_logger.info.assert_any_call(
+            "Current: %s, Latest: %s",
+            "2.0.0",
+            "2.0.0",
+        )
+        mock_logger.info.assert_any_call(
+            "✨ You are running the latest version."
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_check_version_unavailable() -> None:
+    """Check version warns when GitHub is unreachable."""
+    handler = UpgradeHandler()
+    with (
+        patch(
+            "my_unicorn.cli.commands.upgrade.should_perform_self_update",
+            AsyncMock(return_value=(False, None)),
+        ),
+        patch("my_unicorn.cli.commands.upgrade.logger") as mock_logger,
+        patch("my_unicorn.cli.commands.upgrade.__version__", "2.0.0"),
+    ):
+        args = Namespace(check=True)
+        await handler.execute(args)
+        mock_logger.warning.assert_any_call(
+            "Could not determine the latest version. Current: %s",
+            "2.0.0",
+        )

--- a/tests/cli/test_upgrade.py
+++ b/tests/cli/test_upgrade.py
@@ -14,16 +14,14 @@ from my_unicorn.cli.upgrade import (
 )
 
 
-def test_perform_self_update_success() -> None:
-    """Test perform_self_update calls os.execvp with correct arguments."""
+def test_perform_self_update_with_version() -> None:
+    """perform_self_update calls os.execvp with correct tag-based URL."""
     with (
         patch("my_unicorn.cli.upgrade.shutil.which", return_value="uv"),
         patch("my_unicorn.cli.upgrade.os.execvp") as mock_execvp,
     ):
-        mock_execvp.return_value = None  # execvp doesn't return on success
-        perform_self_update()
-        # Since execvp replaces the process, this shouldn't return True
-        # But in test, it will return None, so we check it was called
+        mock_execvp.return_value = None
+        perform_self_update("2.3.0-alpha")
         mock_execvp.assert_called_once_with(
             "uv",
             [
@@ -31,13 +29,33 @@ def test_perform_self_update_success() -> None:
                 "tool",
                 "install",
                 "--upgrade",
-                "git+https://github.com/Cyber-Syntax/my-unicorn",
+                "git+https://github.com/Cyber-Syntax/my-unicorn.git@v2.3.0-alpha",
+            ],
+        )
+
+
+def test_perform_self_update_version_tag_already_prefixed() -> None:
+    """perform_self_update does not double-prefix a version already starting with 'v'."""
+    with (
+        patch("my_unicorn.cli.upgrade.shutil.which", return_value="uv"),
+        patch("my_unicorn.cli.upgrade.os.execvp") as mock_execvp,
+    ):
+        mock_execvp.return_value = None
+        perform_self_update("v2.3.0-alpha")
+        mock_execvp.assert_called_once_with(
+            "uv",
+            [
+                "uv",
+                "tool",
+                "install",
+                "--upgrade",
+                "git+https://github.com/Cyber-Syntax/my-unicorn.git@v2.3.0-alpha",
             ],
         )
 
 
 def test_perform_self_update_failure() -> None:
-    """Test perform_self_update handles execvp failure."""
+    """perform_self_update returns False and logs when execvp raises OSError."""
     with (
         patch("my_unicorn.cli.upgrade.shutil.which", return_value="uv"),
         patch(
@@ -46,11 +64,9 @@ def test_perform_self_update_failure() -> None:
         ),
         patch("my_unicorn.cli.upgrade.logger") as mock_logger,
     ):
-        result = perform_self_update()
+        result = perform_self_update("2.3.0-alpha")
         assert result is False
         mock_logger.exception.assert_called_once()
-        mock_logger.info.assert_called_once()
-        # Check that info was called with the error message format
         call_args = mock_logger.info.call_args
         assert call_args[0][0] == "❌ Update failed: %s"
         assert isinstance(call_args[0][1], OSError)
@@ -59,8 +75,7 @@ def test_perform_self_update_failure() -> None:
 
 @pytest.mark.asyncio
 async def test_check_for_self_update_reports_newer_version() -> None:
-    """Check_for_self_update returns True when a newer version exists."""
-
+    """check_for_self_update returns (True, version) when a newer version exists."""
     with (
         patch(
             "my_unicorn.cli.upgrade._run_uv_tool_list",
@@ -72,14 +87,14 @@ async def test_check_for_self_update_reports_newer_version() -> None:
         ),
         patch("my_unicorn.cli.upgrade.__version__", "2.0.0"),
     ):
-        result = await check_for_self_update()
-        assert result is True
+        should_upgrade, latest_version = await check_for_self_update()
+        assert should_upgrade is True
+        assert latest_version == "2.0.1"
 
 
 @pytest.mark.asyncio
 async def test_check_for_self_update_skips_when_latest() -> None:
-    """Check_for_self_update returns False when already on latest."""
-
+    """check_for_self_update returns (False, version) when already on latest."""
     with (
         patch(
             "my_unicorn.cli.upgrade._run_uv_tool_list",
@@ -91,14 +106,14 @@ async def test_check_for_self_update_skips_when_latest() -> None:
         ),
         patch("my_unicorn.cli.upgrade.__version__", "2.0.0"),
     ):
-        result = await check_for_self_update()
-        assert result is False
+        should_upgrade, latest_version = await check_for_self_update()
+        assert should_upgrade is False
+        assert latest_version == "2.0.0"
 
 
 @pytest.mark.asyncio
 async def test_should_perform_self_update_when_version_unknown() -> None:
-    """Proceed with upgrade when latest version cannot be determined."""
-
+    """Skip upgrade when latest version cannot be determined (no blind upgrades)."""
     with (
         patch(
             "my_unicorn.cli.upgrade._run_uv_tool_list",
@@ -112,24 +127,23 @@ async def test_should_perform_self_update_when_version_unknown() -> None:
         should_upgrade, latest_version = await should_perform_self_update(
             "2.0.0"
         )
-        assert should_upgrade is True
+        assert should_upgrade is False
         assert latest_version is None
 
 
 @pytest.mark.asyncio
 async def test_perform_self_update_async() -> None:
-    """Test perform_self_update_async calls perform_self_update."""
+    """perform_self_update_async forwards version to perform_self_update."""
     with patch("my_unicorn.cli.upgrade.perform_self_update") as mock_perform:
-        mock_perform.return_value = True
-        result = await perform_self_update_async()
-        assert result is True
-        mock_perform.assert_called_once()
+        mock_perform.return_value = False  # execvp never returns True
+        result = await perform_self_update_async("2.3.0-alpha")
+        assert result is False
+        mock_perform.assert_called_once_with("2.3.0-alpha")
 
 
 @pytest.mark.asyncio
 async def test_should_upgrade_dev_installation() -> None:
     """Always upgrade when dev installation is detected."""
-
     with (
         patch(
             "my_unicorn.cli.upgrade._run_uv_tool_list",
@@ -150,8 +164,7 @@ async def test_should_upgrade_dev_installation() -> None:
 
 @pytest.mark.asyncio
 async def test_dev_installation_upgrade_same_version() -> None:
-    """Upgrade dev installation even when version is the same."""
-
+    """Upgrade dev installation even when version matches latest."""
     with (
         patch(
             "my_unicorn.cli.upgrade._run_uv_tool_list",
@@ -166,7 +179,6 @@ async def test_dev_installation_upgrade_same_version() -> None:
         should_upgrade, latest_version = await should_perform_self_update(
             "2.0.0"
         )
-        # Dev installation should always upgrade to production
         assert should_upgrade is True
         assert latest_version == "2.0.0"
 
@@ -174,7 +186,6 @@ async def test_dev_installation_upgrade_same_version() -> None:
 @pytest.mark.asyncio
 async def test_fetch_latest_prerelease_version_disables_cache() -> None:
     """Self-upgrade version check bypasses and disables caching."""
-
     session_cm = AsyncMock()
     session = AsyncMock()
     session_cm.__aenter__.return_value = session

--- a/tests/cli/test_upgrade.py
+++ b/tests/cli/test_upgrade.py
@@ -127,7 +127,7 @@ async def test_should_perform_self_update_when_version_unknown() -> None:
         should_upgrade, latest_version = await should_perform_self_update(
             "2.0.0"
         )
-        assert should_upgrade is False
+        assert should_upgrade is None
         assert latest_version is None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -804,7 +804,7 @@ wheels = [
 
 [[package]]
 name = "my-unicorn"
-version = "2.4.4a0"
+version = "2.5.0a0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Refactors the self-upgrade process to utilize version tags for installation instead of relying on the main branch. The upgrade command now fetches the latest version tag from the GitHub API and constructs the appropriate installation command. This change ensures users can upgrade to the latest stable release without encountering breaking changes from the main branch.

Fixes #275

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation
- [x] I have run `uv run pytest` and `uv run pytest tests/e2e/` to ensure that my changes do not break existing tests
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the git conventional commits (`<type>[optional scope]: <description>`)
