### PR TITLE
feat(verification): improve checksum parsing and add partial verification warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.2-alpha] - 2026-04-30
+
+### Added
+
+- Added support for only `<hash>` in .sha512 checksum files (Fixes #297)
+
+### Fixed
+
+- Wrong hash type detection on .yml/.yaml checksum files
+
 ## [2.5.1-alpha] - 2026-04-30
 
 ### Added

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -29,6 +29,12 @@ uv run pytest tests/test_install.py::test_install_success
 uv run pytest -v -s
 ```
 
+## Learning test specific names
+
+- Example for e2e tests: `pytest --collect-only -q tests/e2e`
+- Example for core: `pytest --collect-only -q tests/core/`
+- Example how to run one test: `uv run pytest tests/e2e/test_full_flow.py::TestFullFlow::test_partial_verification_warnings_joplin_legcord`
+
 ## Test Organization
 
 ### Directory Structure
@@ -72,11 +78,11 @@ Tests are organized with pytest markers:
 
 Fixtures follow a hierarchical organization:
 
-| Fixture Scope | Location | Purpose |
-|---------------|----------|---------|
-| **Global fixtures** | `tests/conftest.py` | Shared across all tests (e.g., `enable_log_propagation`) |
-| **Module-group fixtures** | `tests/<group>/conftest.py` | Shared across submodules (e.g., `tests/core/conftest.py`) |
-| **Module-specific fixtures** | `tests/<module>/conftest.py` | Used only by tests in that module |
+| Fixture Scope                | Location                     | Purpose                                                   |
+| ---------------------------- | ---------------------------- | --------------------------------------------------------- |
+| **Global fixtures**          | `tests/conftest.py`          | Shared across all tests (e.g., `enable_log_propagation`)  |
+| **Module-group fixtures**    | `tests/<group>/conftest.py`  | Shared across submodules (e.g., `tests/core/conftest.py`) |
+| **Module-specific fixtures** | `tests/<module>/conftest.py` | Used only by tests in that module                         |
 
 Pytest automatically discovers fixtures from parent directories, so child tests can use parent fixtures without imports.
 
@@ -201,7 +207,7 @@ def test_with_caplog(caplog):
     """Use caplog for asserting log messages in tests."""
     # caplog captures console output
     my_function_that_logs()
-    
+
     # Assert specific log messages were emitted
     assert "Expected message" in caplog.text
     assert any(record.levelname == "ERROR" for record in caplog.records)
@@ -220,10 +226,10 @@ async def test_install_workflow(caplog, tmp_path):
     """Test installation with both caplog and file logs."""
     # caplog captures console logs for assertions
     result = await install_workflow.execute()
-    
+
     # Assert using caplog
     assert "Installing" in caplog.text
-    
+
     # If test fails, check file logs for full context:
     # tail -f /tmp/pytest-of-$USER-logs/my-unicorn.log
 ```
@@ -277,10 +283,10 @@ For deeper investigation, you can temporarily increase log verbosity:
 def test_with_debug_logging(caplog):
     """Test with DEBUG level logging."""
     caplog.set_level(logging.DEBUG)
-    
+
     # Now all DEBUG messages will be captured
     my_complex_function()
-    
+
     # Check debug logs
     assert "Detailed debug info" in caplog.text
 ```
@@ -308,7 +314,7 @@ def test_file_operations(tmp_path):
     """Always use tmp_path for temporary files."""
     test_file = tmp_path / "test.txt"
     test_file.write_text("content")
-    
+
     # Cleanup is automatic - pytest removes tmp_path after test
     assert test_file.exists()
 ```
@@ -319,7 +325,7 @@ def test_file_operations(tmp_path):
 def test_logging_behavior(caplog):
     """Use caplog to assert log messages."""
     my_function()
-    
+
     assert "Expected message" in caplog.text
     assert caplog.records[0].levelname == "INFO"
 ```
@@ -346,10 +352,10 @@ def test_example():
     # Arrange - Set up test data and mocks
     mock_data = {"key": "value"}
     expected_result = "expected"
-    
+
     # Act - Execute the function under test
     result = my_function(mock_data)
-    
+
     # Assert - Verify the outcome
     assert result == expected_result
 ```
@@ -373,9 +379,9 @@ from unittest.mock import AsyncMock, patch
 async def test_with_mocked_http(mock_session):
     """Mock external HTTP calls."""
     mock_session.get = AsyncMock(return_value=fake_response)
-    
+
     result = await fetch_data()
-    
+
     assert result == expected_data
     mock_session.get.assert_called_once()
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'my-unicorn'
-version = '2.5.1-alpha'
+version = '2.5.2-alpha'
 license = { text = "GPL-3.0-or-later" }
 description = 'My Unicorn is a command-line tool to manage AppImages on Linux. It allows users to install, update, and manage AppImages from GitHub repositories easily. It is designed to simplify the process of handling AppImages, making it more convenient for users to keep their applications up-to-date.'
 keywords = ["appimage", "appimage-manager"]

--- a/scripts/verify_yml.sh
+++ b/scripts/verify_yml.sh
@@ -10,7 +10,7 @@ cleanup() { :; }
 
 handle_signal() {
   printf '[ERROR] Signal received: %s\n' "${1:-UNKNOWN}" >&2
-  return 1
+  exit 1
 }
 
 trap 'handle_signal INT' INT
@@ -51,8 +51,6 @@ find_yaml_file() {
   }
 
   log_data "YAML file" "${file}"
-
-  # ONLY raw output for capture
   printf '%s\n' "${file}"
 }
 
@@ -63,7 +61,7 @@ extract_appimage() {
   value=$(sed -n 's/^path:[[:space:]]*\(.*\.AppImage\)$/\1/p' "$yaml" | head -n 1)
 
   [[ -n "${value// /}" ]] || {
-    log_error "Failed to parse AppImage path"
+    log_error "Failed to parse AppImage"
     return 1
   }
 
@@ -75,9 +73,7 @@ extract_sha512_base64() {
   local yaml="$1"
   local value
 
-  value=$(awk '
-        /^path:.*AppImage$/ {getline; if ($1=="sha512:") print $2}
-    ' "$yaml")
+  value=$(awk '/^path:.*AppImage$/ {getline; if ($1=="sha512:") print $2}' "$yaml")
 
   [[ -n "${value// /}" ]] || {
     log_error "Failed to extract base64 sha512"
@@ -99,7 +95,7 @@ base64_to_hex() {
     return 1
   }
 
-  log_data "HEX expected" "${hex}"
+  log_data "Expected HEX" "${hex}"
   printf '%s\n' "${hex}"
 }
 
@@ -114,7 +110,7 @@ sha512_file() {
     return 1
   }
 
-  log_data "HEX actual" "${hash}"
+  log_data "Actual HEX" "${hash}"
   printf '%s\n' "${hash}"
 }
 

--- a/scripts/verify_yml.sh
+++ b/scripts/verify_yml.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -o pipefail
+
+APPIMAGE_PATH="${HOME}/Downloads"
+CHECKSUM_FILE_NAME="latest-linux.yml"
+
+cleanup() { :; }
+
+handle_signal() {
+  printf '[ERROR] Signal received: %s\n' "${1:-UNKNOWN}" >&2
+  return 1
+}
+
+trap 'handle_signal INT' INT
+trap 'handle_signal TERM' TERM
+
+log_info() { printf '[INFO] %s\n' "$1" >&2; }
+log_error() { printf '[ERROR] %s\n' "$1" >&2; }
+log_data() { printf '[DATA] %-24s : %s\n' "$1" "$2" >&2; }
+
+validate_dependencies() {
+  for cmd in find sed base64 xxd sha512sum awk; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+      log_error "Missing dependency: $cmd"
+      return 1
+    }
+  done
+  log_info "Dependencies OK"
+}
+
+validate_directory() {
+  [[ -d "${APPIMAGE_PATH}" ]] || {
+    log_error "Missing directory: ${APPIMAGE_PATH}"
+    return 1
+  }
+  log_data "Download dir" "${APPIMAGE_PATH}"
+}
+
+find_yaml_file() {
+  local file
+
+  log_info "Searching YAML file"
+
+  file=$(find "${APPIMAGE_PATH}" -maxdepth 1 -type f -name "${CHECKSUM_FILE_NAME}" 2>/dev/null | head -n 1)
+
+  [[ -n "${file// /}" ]] || {
+    log_error "YAML not found"
+    return 1
+  }
+
+  log_data "YAML file" "${file}"
+
+  # ONLY raw output for capture
+  printf '%s\n' "${file}"
+}
+
+extract_appimage() {
+  local yaml="$1"
+  local value
+
+  value=$(sed -n 's/^path:[[:space:]]*\(.*\.AppImage\)$/\1/p' "$yaml" | head -n 1)
+
+  [[ -n "${value// /}" ]] || {
+    log_error "Failed to parse AppImage path"
+    return 1
+  }
+
+  log_data "AppImage" "${value}"
+  printf '%s\n' "${value}"
+}
+
+extract_sha512_base64() {
+  local yaml="$1"
+  local value
+
+  value=$(awk '
+        /^path:.*AppImage$/ {getline; if ($1=="sha512:") print $2}
+    ' "$yaml")
+
+  [[ -n "${value// /}" ]] || {
+    log_error "Failed to extract base64 sha512"
+    return 1
+  }
+
+  log_data "Base64 SHA512" "${value}"
+  printf '%s\n' "${value}"
+}
+
+base64_to_hex() {
+  local b64="$1"
+  local hex
+
+  hex=$(printf '%s' "$b64" | base64 -d 2>/dev/null | xxd -p -c 256)
+
+  [[ -n "${hex// /}" ]] || {
+    log_error "Base64 decode failed"
+    return 1
+  }
+
+  log_data "HEX expected" "${hex}"
+  printf '%s\n' "${hex}"
+}
+
+sha512_file() {
+  local file="$1"
+  local hash
+
+  hash=$(sha512sum "$file" | awk '{print $1}')
+
+  [[ -n "${hash// /}" ]] || {
+    log_error "sha512 failed"
+    return 1
+  }
+
+  log_data "HEX actual" "${hash}"
+  printf '%s\n' "${hash}"
+}
+
+verify() {
+  local file="$1"
+  local expected="$2"
+  local actual
+
+  actual=$(sha512_file "$file")
+
+  printf '\n[COMPARE]\n' >&2
+  log_data "Expected" "$expected"
+  log_data "Actual" "$actual"
+
+  [[ "$expected" == "$actual" ]] && {
+    printf '[SUCCESS] Match\n'
+    return 0
+  }
+
+  log_error "Mismatch"
+  return 1
+}
+
+main() {
+  local yaml appimage b64 expected file
+
+  validate_dependencies || return 1
+  validate_directory || return 1
+
+  yaml=$(find_yaml_file) || return 1
+  appimage=$(extract_appimage "$yaml") || return 1
+
+  file="${APPIMAGE_PATH}/${appimage}"
+
+  [[ -f "$file" ]] || {
+    log_error "Missing AppImage: $file"
+    return 1
+  }
+
+  b64=$(extract_sha512_base64 "$yaml") || return 1
+  expected=$(base64_to_hex "$b64") || return 1
+
+  verify "$file" "$expected"
+}
+
+main "$@"

--- a/src/my_unicorn/core/verification/checksum_parser/detector.py
+++ b/src/my_unicorn/core/verification/checksum_parser/detector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from my_unicorn.constants import YAML_DEFAULT_HASH, HashType
 from my_unicorn.core.verification.checksum_parser.bsd_parser import (
     BSDChecksumParser,
     _looks_like_bsd,
@@ -23,7 +24,6 @@ from my_unicorn.logger import get_logger
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from my_unicorn.constants import HashType
     from my_unicorn.core.verification.checksum_parser.base import (
         ChecksumEntry,
         ChecksumParser,
@@ -88,9 +88,9 @@ def detect_hash_type_from_checksum_filename(
     filename_lower = filename.lower()
 
     hash_patterns: dict[HashType, Iterable[str]] = {
-        "sha512": ["sha512", "sha-512"],
-        "sha256": ["sha256", "sha-256"],
-        "sha1": ["sha1", "sha-1"],
+        "sha512": ["sha512"],
+        "sha256": ["sha256"],
+        "sha1": ["sha1"],
         "md5": ["md5"],
     }
 
@@ -100,7 +100,7 @@ def detect_hash_type_from_checksum_filename(
             return hash_type
 
     if filename_lower.endswith((".yml", ".yaml")):
-        return "sha256"
+        return YAML_DEFAULT_HASH
 
     return None
 

--- a/src/my_unicorn/core/verification/checksum_parser/traditional_parser.py
+++ b/src/my_unicorn/core/verification/checksum_parser/traditional_parser.py
@@ -19,6 +19,9 @@ _HASH_LENGTH_MAP: dict[int, HashType] = {
     64: "sha256",
     128: "sha512",
 }
+_HASH_TYPE_LENGTH_MAP: dict[HashType, int] = {
+    hash_type: length for length, hash_type in _HASH_LENGTH_MAP.items()
+}
 
 
 def _parse_sha256sums_line(line: str) -> tuple[str, str] | None:
@@ -63,19 +66,49 @@ def _generate_variants(name: str) -> set[str]:
     return {variant for variant in variants if variant}
 
 
+def _parse_hash_only_content(content: str, hash_type: HashType) -> str | None:
+    """Parse checksum files that contain a single raw hash only.
+
+    This is used for formats like `.sha512` files that sometimes
+    contain only a hash without filename mapping.
+
+    Rules:
+    - Must contain exactly one non-empty, non-comment line
+    - Must be a valid hex string
+    - Must match the expected hash length for the detected hash type
+    """
+    lines = [
+        line.strip()
+        for line in content.strip().split("\n")
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    if len(lines) != 1:
+        return None
+
+    candidate = lines[0]
+
+    if not all(c in "0123456789abcdefABCDEF" for c in candidate):
+        return None
+
+    expected_length = _HASH_TYPE_LENGTH_MAP[hash_type]
+    if len(candidate) != expected_length:
+        logger.debug(
+            "   Hash-only candidate length %d does not match %s length %d",
+            len(candidate),
+            hash_type,
+            expected_length,
+        )
+        return None
+
+    return candidate
+
+
 def _parse_traditional_checksum_file(
     content: str, filename: str, hash_type: HashType
 ) -> str | None:
-    """Parse a traditional checksum file (e.g., SHA256SUMS).
+    """Parse a traditional checksum file (e.g., SHA256SUMS)."""
 
-    Args:
-        content: The file content.
-        filename: The filename to find the hash for.
-        hash_type: The expected hash type.
-
-    Returns:
-        The hash value as string or None if not found.
-    """
     logger.debug("   Parsing as traditional checksum file format")
     logger.debug("   Looking for: %s", filename)
     logger.debug("   Hash type: %s", hash_type)
@@ -85,6 +118,16 @@ def _parse_traditional_checksum_file(
 
     target_variants = _generate_variants(filename)
 
+    # Hash-only fallback for .sha256/.sha512 style files. The checksum
+    # filename is not available here, so rely on the already-detected hash
+    # type passed by the caller and validate the raw hash length strictly.
+    hash_only = _parse_hash_only_content(content, hash_type)
+    if hash_only:
+        logger.debug("   ✅ Hash-only checksum detected (fallback mode)")
+        logger.debug("   Hash: %s", hash_only)
+        return hash_only
+
+    # Standard filename-based parsing
     for line_num, raw_line in enumerate(lines, 1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
@@ -107,6 +150,7 @@ def _parse_traditional_checksum_file(
             file_in_checksum,
         )
 
+        # direct match
         if file_in_checksum == filename or file_in_checksum.endswith(
             f"/{filename}"
         ):
@@ -114,6 +158,7 @@ def _parse_traditional_checksum_file(
             logger.debug("   Hash: %s", hash_value)
             return hash_value
 
+        # relaxed variant match
         file_variants = _generate_variants(file_in_checksum)
         if target_variants.intersection(file_variants):
             logger.debug(

--- a/src/my_unicorn/core/verification/checksum_parser/yaml_parser.py
+++ b/src/my_unicorn/core/verification/checksum_parser/yaml_parser.py
@@ -175,8 +175,9 @@ def _parse_all_yaml_checksums(content: str) -> dict[str, str]:
 
     hashes: dict[str, str] = {}
 
-    # electron-builder: files is a list of {url, sha512, size}
     files = data.get("files")
+
+    # electron-builder format: files is a list of {url/name, sha512, size}
     if isinstance(files, list):
         for entry in files:
             if not isinstance(entry, dict):
@@ -189,7 +190,18 @@ def _parse_all_yaml_checksums(content: str) -> dict[str, str]:
                 hash_value, _ = result
                 hashes[filename] = hash_value
 
-    # Also capture root-level entry (primary file)
+    # Generic format: files is a dict of {filename: hash_str_or_dict}
+    elif isinstance(files, dict):
+        for filename, hash_data in files.items():
+            if isinstance(hash_data, str):
+                hashes[filename] = _normalize_hash_value(hash_data)
+            elif isinstance(hash_data, dict):
+                result = _extract_hash_from_dict(hash_data)
+                if result:
+                    hash_value, _ = result
+                    hashes[filename] = hash_value
+
+    # Capture root-level entry (electron-builder also has path/sha512 at root)
     root_path = data.get("path")
     if root_path:
         result = _extract_hash_from_dict(data)
@@ -197,15 +209,12 @@ def _parse_all_yaml_checksums(content: str) -> dict[str, str]:
             hash_value, _ = result
             hashes[root_path] = hash_value
 
-    # Fallback: generic {filename: hash_str} flat structure
+    # Fallback: flat {filename: hash} with no "files" key
     if not hashes:
         for key, value in data.items():
-            if isinstance(value, str) and key not in (
-                "version",
-                "path",
-                "releaseDate",
-                "releaseNotes",
-            ):
+            if key in ("version", "path", "releaseDate", "releaseNotes"):
+                continue
+            if isinstance(value, str):
                 hashes[key] = _normalize_hash_value(value)
             elif isinstance(value, dict):
                 result = _extract_hash_from_dict(value)

--- a/src/my_unicorn/core/verification/checksum_parser/yaml_parser.py
+++ b/src/my_unicorn/core/verification/checksum_parser/yaml_parser.py
@@ -161,37 +161,57 @@ def _parse_yaml_checksum_file(
 
 
 def _parse_all_yaml_checksums(content: str) -> dict[str, str]:
-    """Parse all filename-to-hash mappings from YAML checksum format.
-
-    Args:
-        content: The YAML checksum file content.
-
-    Returns:
-        Dictionary mapping filenames to hash values.
-
-    """
+    """Parse all filename-to-hash mappings from YAML checksum format."""
     if not _YAML_AVAILABLE or not yaml:
         return {}
-
-    hashes: dict[str, str] = {}
 
     try:
         data = yaml.safe_load(content)
         if not isinstance(data, dict):
             return {}
-
-        for filename, hash_data in data.items():
-            if isinstance(hash_data, dict):
-                result = _extract_hash_from_dict(hash_data)
-                if result:
-                    hash_value, _ = result
-                    hashes[filename] = hash_value
-            elif isinstance(hash_data, str):
-                hashes[filename] = _normalize_hash_value(hash_data)
-
     except yaml.YAMLError:
         logger.debug("Failed to parse YAML for all checksums")
         return {}
+
+    hashes: dict[str, str] = {}
+
+    # electron-builder: files is a list of {url, sha512, size}
+    files = data.get("files")
+    if isinstance(files, list):
+        for entry in files:
+            if not isinstance(entry, dict):
+                continue
+            filename = entry.get("url") or entry.get("name")
+            if not filename:
+                continue
+            result = _extract_hash_from_dict(entry)
+            if result:
+                hash_value, _ = result
+                hashes[filename] = hash_value
+
+    # Also capture root-level entry (primary file)
+    root_path = data.get("path")
+    if root_path:
+        result = _extract_hash_from_dict(data)
+        if result:
+            hash_value, _ = result
+            hashes[root_path] = hash_value
+
+    # Fallback: generic {filename: hash_str} flat structure
+    if not hashes:
+        for key, value in data.items():
+            if isinstance(value, str) and key not in (
+                "version",
+                "path",
+                "releaseDate",
+                "releaseNotes",
+            ):
+                hashes[key] = _normalize_hash_value(value)
+            elif isinstance(value, dict):
+                result = _extract_hash_from_dict(value)
+                if result:
+                    hash_value, _ = result
+                    hashes[key] = hash_value
 
     return hashes
 

--- a/tests/core/verification/test_checksum_detector.py
+++ b/tests/core/verification/test_checksum_detector.py
@@ -162,6 +162,24 @@ def789abc123 other.bin
     assert hash_value == "abc123def456"
 
 
+def test_parse_traditional_hash_only_sha512_checksum_file() -> None:
+    """Test parsing checksum files that contain only a SHA512 hash."""
+    hash_value = parse_checksum_file(
+        LEGCORD_EXPECTED_HEX, "Joplin-3.5.13.AppImage", "sha512"
+    )
+
+    assert hash_value == LEGCORD_EXPECTED_HEX
+
+
+def test_parse_traditional_hash_only_rejects_wrong_hash_type() -> None:
+    """Test hash-only checksums must match the expected algorithm length."""
+    hash_value = parse_checksum_file(
+        LEGCORD_EXPECTED_HEX, "Joplin-3.5.13.AppImage", "sha256"
+    )
+
+    assert hash_value is None
+
+
 def test_parse_checksum_file_auto_detect_yaml() -> None:
     hash_value = parse_checksum_file(
         LEGCORD_YAML_CONTENT,
@@ -191,7 +209,7 @@ def test_detect_hash_type_from_filename() -> None:
     assert detect_hash_type_from_checksum_filename("checksums.sha1") == "sha1"
     assert detect_hash_type_from_checksum_filename("hashes.md5") == "md5"
     assert (
-        detect_hash_type_from_checksum_filename("latest-linux.yml") == "sha256"
+        detect_hash_type_from_checksum_filename("latest-linux.yml") == "sha512"
     )
 
 

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -6,6 +6,7 @@ commands in a sandboxed environment, with utilities for config manipulation.
 
 import os
 import subprocess
+from pathlib import Path
 from typing import Any, cast
 
 import orjson
@@ -52,9 +53,12 @@ class E2ERunner:
         # Build the command using uv run (executing from source)
         cmd = ["uv", "run", "my-unicorn", *args]
 
-        # Set up environment with sandbox HOME
+        # Set up environment with sandbox HOME and sandbox-scoped logs.
+        # pytest sets MY_UNICORN_LOG_DIR globally, so override it here to
+        # keep each E2E subprocess isolated and make its logs inspectable.
         env = os.environ.copy()
         env["HOME"] = str(self.sandbox.temp_home)
+        env["MY_UNICORN_LOG_DIR"] = str(self.log_file_path().parent)
 
         # Merge custom environment variables if provided
         if env_overrides:
@@ -68,6 +72,23 @@ class E2ERunner:
             env=env,
             capture_output=True,
         )
+
+    def log_file_path(self) -> Path:
+        """Return the sandbox-scoped my-unicorn log file path."""
+        return (
+            self.sandbox.temp_home
+            / ".config"
+            / "my-unicorn"
+            / "logs"
+            / "my-unicorn.log"
+        )
+
+    def read_log(self) -> str:
+        """Read the sandbox-scoped my-unicorn log file if it exists."""
+        log_file = self.log_file_path()
+        if not log_file.exists():
+            return ""
+        return log_file.read_text(encoding="utf-8")
 
     def install(
         self, app_name: str, *args: str

--- a/tests/e2e/test_full_flow.py
+++ b/tests/e2e/test_full_flow.py
@@ -17,6 +17,7 @@ import pytest
 
 from tests.e2e.runner import E2ERunner
 from tests.e2e.sandbox import SandboxEnvironment
+from tests.e2e.warnings import warn_on_partial_verification
 
 
 @pytest.mark.e2e
@@ -158,6 +159,34 @@ class TestFullFlow:
                 assert "version" in config.get("state", {}), (
                     f"{app_name} config missing state.version field"
                 )
+
+    def test_partial_verification_warnings_joplin_legcord(
+        self,
+        sandbox_env: SandboxEnvironment,
+        e2e_runner: E2ERunner,
+    ) -> None:
+        """Warn about partial verification for joplin and legcord if seen.
+
+        These apps have historically produced partial verification when one
+        verification method passes and another fails. That may be caused by an
+        external release metadata/checksum issue, so installation should still
+        succeed and pytest should emit a warning when partial verification is
+        detected.
+
+        If both apps verify cleanly, this test should pass without warnings.
+        Because downloads run concurrently, output order is not guaranteed.
+        """
+        with sandbox_env:
+            result = e2e_runner.install("joplin", "legcord")
+
+            assert result.returncode == 0, f"Install failed: {result.stderr}"
+
+            cli_log = e2e_runner.read_log()
+            diagnostic_output = f"{result.stdout}\n{result.stderr}\n{cli_log}"
+            warn_on_partial_verification(
+                diagnostic_output,
+                "install",
+            )
 
     def test_updates_multiple_apps(
         self, sandbox_env: SandboxEnvironment, e2e_runner: E2ERunner

--- a/tests/e2e/test_warnings.py
+++ b/tests/e2e/test_warnings.py
@@ -1,0 +1,67 @@
+"""Tests for E2E warning detection helpers."""
+
+import warnings
+
+from tests.e2e.warnings import (
+    PartialVerificationWarning,
+    find_partial_verifications,
+    warn_on_partial_verification,
+)
+
+
+def test_find_partial_verifications_from_cli_summary() -> None:
+    """Detect partial verification from user-facing install summary."""
+    text = "⚠️  Partial verification: 2 passed, 1 failed"
+
+    matches = find_partial_verifications(text, "legcord")
+
+    assert len(matches) == 1
+    assert matches[0].app_name == "legcord"
+    assert matches[0].passed_count == 2
+    assert matches[0].failed_count == 1
+
+
+def test_find_partial_verifications_from_log_message() -> None:
+    """Detect partial verification from detailed application logs."""
+    text = (
+        "Partial verification success for joplin: "
+        "digest passed, checksum_file failed"
+    )
+
+    matches = find_partial_verifications(text, "install")
+
+    assert len(matches) == 1
+    assert matches[0].app_name == "joplin"
+    assert matches[0].passed_count == 1
+    assert matches[0].failed_count == 1
+
+
+def test_warn_on_partial_verification_emits_warning() -> None:
+    """Emit pytest-visible warnings when partial verification is detected."""
+    text = (
+        "Partial verification success for joplin: "
+        "digest passed, checksum_file failed"
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        warning_count = warn_on_partial_verification(text, "install")
+
+    assert warning_count == 1
+    assert len(captured) == 1
+    assert issubclass(captured[0].category, PartialVerificationWarning)
+    assert "joplin partial verification: 1 passed, 1 failed" in str(
+        captured[0].message
+    )
+
+
+def test_warn_on_partial_verification_ignores_complete_success() -> None:
+    """Do not emit warnings when no failed methods are present."""
+    text = "Partial verification: 2 passed, 0 failed"
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        warning_count = warn_on_partial_verification(text, "legcord")
+
+    assert warning_count == 0
+    assert captured == []

--- a/tests/e2e/warnings.py
+++ b/tests/e2e/warnings.py
@@ -1,0 +1,99 @@
+"""Warning detection helpers for E2E CLI subprocess output."""
+
+import re
+import warnings
+from dataclasses import dataclass
+
+SUMMARY_PARTIAL_VERIFICATION_PATTERN = re.compile(
+    r"Partial verification:\s*(\d+)\s*passed,\s*(\d+)\s*failed",
+    re.IGNORECASE,
+)
+LOG_PARTIAL_VERIFICATION_PATTERN = re.compile(
+    r"Partial verification success for\s+(?P<app>[\w.-]+):\s*"
+    r"(?P<passed>[\w, _-]+)\s+passed,\s*"
+    r"(?P<failed>[\w, _-]+)\s+failed",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PartialVerificationMatch:
+    """Partial verification details detected in CLI output or logs."""
+
+    app_name: str
+    passed_count: int
+    failed_count: int
+
+
+class PartialVerificationWarning(UserWarning):
+    """Raised when install succeeds but verification is only partial."""
+
+
+def _count_methods(methods_text: str) -> int:
+    """Count comma-separated verification method names."""
+    return len(
+        [method for method in methods_text.split(",") if method.strip()]
+    )
+
+
+def find_partial_verifications(
+    text: str,
+    default_app_name: str,
+) -> list[PartialVerificationMatch]:
+    """Find partial verification summaries in CLI output or log text."""
+    matches: list[PartialVerificationMatch] = []
+
+    for passed_str, failed_str in SUMMARY_PARTIAL_VERIFICATION_PATTERN.findall(
+        text
+    ):
+        failed_count = int(failed_str)
+        if failed_count > 0:
+            matches.append(
+                PartialVerificationMatch(
+                    app_name=default_app_name,
+                    passed_count=int(passed_str),
+                    failed_count=failed_count,
+                )
+            )
+
+    for log_match in LOG_PARTIAL_VERIFICATION_PATTERN.finditer(text):
+        failed_count = _count_methods(log_match.group("failed"))
+        if failed_count > 0:
+            matches.append(
+                PartialVerificationMatch(
+                    app_name=log_match.group("app"),
+                    passed_count=_count_methods(log_match.group("passed")),
+                    failed_count=failed_count,
+                )
+            )
+
+    return matches
+
+
+def warn_on_partial_verification(text: str, app_name: str) -> int:
+    """
+    Emit pytest warning if CLI output or logs contain partial verification.
+
+    Example CLI summary matched text:
+        Partial verification: 1 passed, 1 failed
+
+    Example log matched text:
+        Partial verification success for joplin: digest passed,
+        checksum_file failed
+
+    Returns:
+        Number of warnings emitted.
+    """
+    matches = find_partial_verifications(text, app_name)
+
+    for match in matches:
+        warnings.warn(
+            (
+                f"{match.app_name} partial verification: "
+                f"{match.passed_count} passed, {match.failed_count} failed"
+            ),
+            PartialVerificationWarning,
+            stacklevel=2,
+        )
+
+    return len(matches)

--- a/uv.lock
+++ b/uv.lock
@@ -804,7 +804,7 @@ wheels = [
 
 [[package]]
 name = "my-unicorn"
-version = "2.5.1a0"
+version = "2.5.2a0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION


## Problem



Checksum verification fails when only a hash is present in the checksum file, leading to installation issues for certain applications like Joplin. This pull request addresses the need for improved parsing of checksum files and the ability to handle cases where only a hash is provided.



## Solution



Enhancements include support for hash-only content in traditional checksum parsing and improved YAML checksum parsing. Additionally, the end-to-end testing framework has been extended to include tests for partial verification warnings, ensuring that users are notified when one verification method passes while another fails.



## Type of Change



- [x] Bug fix

- [x] New feature



## Checklist



- If you changed python module:

- [x] Run all fast tests: `uv run pytest -m 'not slow'`

- [x] Run e2e tests: `uv run pytest tests/e2e/` (WARNING: This tests would use real api connection, make sure you setup your token. Also, this would take time according to your internet speed.)

- [x] Add your test (if you can)

- [x] Add/update docs

