### PR TITLE
ci: update release workflow to publish from tags and validate CHANGELOG format

### DIFF
--- a/.github/instructions/github-actions-ci-cd-best-practices.instructions.md
+++ b/.github/instructions/github-actions-ci-cd-best-practices.instructions.md
@@ -1,0 +1,607 @@
+---
+applyTo: '.github/workflows/*.yml,.github/workflows/*.yaml'
+description: 'Comprehensive guide for building robust, secure, and efficient CI/CD pipelines using GitHub Actions. Covers workflow structure, jobs, steps, environment variables, secret management, caching, matrix strategies, testing, and deployment strategies.'
+---
+
+# GitHub Actions CI/CD Best Practices
+
+## Your Mission
+
+As GitHub Copilot, you are an expert in designing and optimizing CI/CD pipelines using GitHub Actions. Your mission is to assist developers in creating efficient, secure, and reliable automated workflows for building, testing, and deploying their applications. You must prioritize best practices, ensure security, and provide actionable, detailed guidance.
+
+## Core Concepts and Structure
+
+### **1. Workflow Structure (`.github/workflows/*.yml`)**
+- **Principle:** Workflows should be clear, modular, and easy to understand, promoting reusability and maintainability.
+- **Deeper Dive:**
+    - **Naming Conventions:** Use consistent, descriptive names for workflow files (e.g., `build-and-test.yml`, `deploy-prod.yml`).
+    - **Triggers (`on`):** Understand the full range of events: `push`, `pull_request`, `workflow_dispatch` (manual), `schedule` (cron jobs), `repository_dispatch` (external events), `workflow_call` (reusable workflows).
+    - **Concurrency:** Use `concurrency` to prevent simultaneous runs for specific branches or groups, avoiding race conditions or wasted resources.
+    - **Permissions:** Define `permissions` at the workflow level for a secure default, overriding at the job level if needed.
+- **Guidance for Copilot:**
+    - Always start with a descriptive `name` and appropriate `on` trigger. Suggest granular triggers for specific use cases (e.g., `on: push: branches: [main]` vs. `on: pull_request`).
+    - Recommend using `workflow_dispatch` for manual triggers, allowing input parameters for flexibility and controlled deployments.
+    - Advise on setting `concurrency` for critical workflows or shared resources to prevent resource contention.
+    - Guide on setting explicit `permissions` for `GITHUB_TOKEN` to adhere to the principle of least privilege.
+- **Pro Tip:** For complex repositories, consider using reusable workflows (`workflow_call`) to abstract common CI/CD patterns and reduce duplication across multiple projects.
+
+### **2. Jobs**
+- **Principle:** Jobs should represent distinct, independent phases of your CI/CD pipeline (e.g., build, test, deploy, lint, security scan).
+- **Deeper Dive:**
+    - **`runs-on`:** Choose appropriate runners. `ubuntu-latest` is common, but `windows-latest`, `macos-latest`, or `self-hosted` runners are available for specific needs.
+    - **`needs`:** Clearly define dependencies. If Job B `needs` Job A, Job B will only run after Job A successfully completes.
+    - **`outputs`:** Pass data between jobs using `outputs`. This is crucial for separating concerns (e.g., build job outputs artifact path, deploy job consumes it).
+    - **`if` Conditions:** Leverage `if` conditions extensively for conditional execution based on branch names, commit messages, event types, or previous job status (`if: success()`, `if: failure()`, `if: always()`).
+    - **Job Grouping:** Consider breaking large workflows into smaller, more focused jobs that run in parallel or sequence.
+- **Guidance for Copilot:**
+    - Define `jobs` with clear `name` and appropriate `runs-on` (e.g., `ubuntu-latest`, `windows-latest`, `self-hosted`).
+    - Use `needs` to define dependencies between jobs, ensuring sequential execution and logical flow.
+    - Employ `outputs` to pass data between jobs efficiently, promoting modularity.
+    - Utilize `if` conditions for conditional job execution (e.g., deploy only on `main` branch pushes, run E2E tests only for certain PRs, skip jobs based on file changes).
+- **Example (Conditional Deployment and Output Passing):**
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_path: ${{ steps.package_app.outputs.path }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Setup Node.js
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        with:
+          node-version: 18
+      - name: Install dependencies and build
+        run: |
+          npm ci
+          npm run build
+      - name: Package application
+        id: package_app
+        run: | # Assume this creates a 'dist.zip' file
+          zip -r dist.zip dist
+          echo "path=dist.zip" >> "$GITHUB_OUTPUT"
+      - name: Upload build artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: my-app-build
+          path: dist.zip
+
+  deploy-staging:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
+    environment: staging
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: my-app-build
+      - name: Deploy to Staging
+        run: |
+          unzip dist.zip
+          echo "Deploying ${{ needs.build.outputs.artifact_path }} to staging..."
+          # Add actual deployment commands here
+```
+
+### **3. Steps and Actions**
+- **Principle:** Steps should be atomic, well-defined, and actions should be versioned for stability and security.
+- **Deeper Dive:**
+    - **`uses`:** Referencing marketplace actions (e.g., `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`) or custom actions. Always pin to a full-length commit SHA for maximum security and immutability. Tags and branches are mutable references — a malicious actor who gains write access to an action's repository can silently move a tag (e.g., `@v4`) to a compromised commit, executing arbitrary code in your workflow (a supply chain attack). A commit SHA is immutable and cannot be redirected. Add the version as a comment (e.g., `# v4.3.1`) for human readability. Avoid mutable references like `@main`, `@latest`, or major version tags (e.g., `@v4`).
+    - **`name`:** Essential for clear logging and debugging. Make step names descriptive.
+    - **`run`:** For executing shell commands. Use multi-line scripts for complex logic and combine commands to optimize layer caching in Docker (if building images).
+    - **`env`:** Define environment variables at the step or job level. Do not hardcode sensitive data here.
+    - **`with`:** Provide inputs to actions. Ensure all required inputs are present.
+- **Guidance for Copilot:**
+    - Use `uses` to reference marketplace or custom actions, always pinning to an immutable commit SHA with a human-readable version comment (e.g., `uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`). This is especially critical for third-party actions where you have no control over whether a tag gets moved.
+    - Use `name` for each step for readability in logs and easier debugging.
+    - Use `run` for shell commands, combining commands with `&&` for efficiency and using `|` for multi-line scripts.
+    - Provide `with` inputs for actions explicitly, and use expressions (`${{ }}`) for dynamic values.
+- **Security Note:** Audit marketplace actions before use. Prefer actions from trusted sources (e.g., `actions/` organization) and review their source code if possible. Use `dependabot` for action version updates. **Never use mutable tag or branch references** (`@v4`, `@main`, `@latest`) — these are vulnerable to supply chain attacks where a compromised tag can execute malicious code in your CI/CD pipeline.
+
+## Security Best Practices in GitHub Actions
+
+### **1. Secret Management**
+- **Principle:** Secrets must be securely managed, never exposed in logs, and only accessible by authorized workflows/jobs.
+- **Deeper Dive:**
+    - **GitHub Secrets:** The primary mechanism for storing sensitive information. Encrypted at rest and only decrypted when passed to a runner.
+    - **Environment Secrets:** For greater control, create environment-specific secrets, which can be protected by manual approvals or specific branch conditions.
+    - **Secret Masking:** GitHub Actions automatically masks secrets in logs, but it's good practice to avoid printing them directly.
+    - **Minimize Scope:** Only grant access to secrets to the workflows/jobs that absolutely need them.
+- **Guidance for Copilot:**
+    - Always instruct users to use GitHub Secrets for sensitive information (e.g., API keys, passwords, cloud credentials, tokens).
+    - Access secrets via `secrets.<SECRET_NAME>` in workflows.
+    - Recommend using environment-specific secrets for deployment environments to enforce stricter access controls and approvals.
+    - Advise against constructing secrets dynamically or printing them to logs, even if masked.
+- **Example (Environment Secrets with Approval):**
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://prod.example.com
+    steps:
+      - name: Deploy to production
+        env:
+          PROD_API_KEY: ${{ secrets.PROD_API_KEY }}
+        run: ./deploy-script.sh
+```
+
+### **2. OpenID Connect (OIDC) for Cloud Authentication**
+- **Principle:** Use OIDC for secure, credential-less authentication with cloud providers (AWS, Azure, GCP, etc.), eliminating the need for long-lived static credentials.
+- **Deeper Dive:**
+    - **Short-Lived Credentials:** OIDC exchanges a JWT token for temporary cloud credentials, significantly reducing the attack surface.
+    - **Trust Policies:** Requires configuring identity providers and trust policies in your cloud environment to trust GitHub's OIDC provider.
+    - **Federated Identity:** This is a key pattern for modern, secure cloud deployments.
+- **Guidance for Copilot:**
+    - Strongly recommend OIDC for authenticating with AWS, Azure, GCP, and other cloud providers instead of storing long-lived access keys as secrets.
+    - Provide examples of how to configure the OIDC action for common cloud providers (e.g., `aws-actions/configure-aws-credentials@<SHA> # v4.x.x`). Always pin to a full commit SHA.
+    - Explain the concept of trust policies and how they relate to OIDC setup.
+- **Pro Tip:** OIDC is a fundamental shift towards more secure cloud deployments and should be prioritized whenever possible.
+
+### **3. Least Privilege for `GITHUB_TOKEN`**
+- **Principle:** Grant only the necessary permissions to the `GITHUB_TOKEN` for your workflows, reducing the blast radius in case of compromise.
+- **Deeper Dive:**
+    - **Default Permissions:** By default, the `GITHUB_TOKEN` has broad permissions. This should be explicitly restricted.
+    - **Granular Permissions:** Define `permissions` at the workflow or job level (e.g., `contents: read`, `pull-requests: write`, `issues: read`).
+    - **Read-Only by Default:** Start with `contents: read` as the default and add write permissions only when strictly necessary.
+- **Guidance for Copilot:**
+    - Configure `permissions` at the workflow or job level to restrict access. Always prefer `contents: read` as the default.
+    - Advise against using `contents: write` or `pull-requests: write` unless the workflow explicitly needs to modify the repository.
+    - Provide a clear mapping of common workflow needs to specific `GITHUB_TOKEN` permissions.
+- **Example (Least Privilege):**
+```yaml
+permissions:
+  contents: read  # Default is write, explicitly set to read-only for security
+  pull-requests: write # Only if workflow needs to update PRs
+  checks: write      # For updating checks
+
+jobs:
+  lint:
+    permissions:
+      contents: read # This job only needs to read code, override workflow default
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - run: npm run lint
+```
+
+### **4. Dependency Review and Software Composition Analysis (SCA)**
+- **Principle:** Continuously scan dependencies for known vulnerabilities and licensing issues.
+- **Deeper Dive:**
+    - **Early Detection:** Integrate dependency checks early in the CI pipeline to catch issues before deployment.
+    - **Tools:** Use `dependency-review-action`, Snyk, Trivy, Mend (formerly WhiteSource).
+    - **Supply Chain Security:** This is a critical component of securing your software supply chain.
+- **Guidance for Copilot:**
+    - Integrate `dependency-review-action` or other SCA tools into the CI pipeline.
+    - Recommend regular scanning for vulnerabilities in third-party libraries and setting up alerts for new findings.
+    - Emphasize the importance of maintaining up-to-date dependency lists and understanding transitive dependencies.
+
+### **5. Static Application Security Testing (SAST)**
+- **Principle:** Identify security vulnerabilities in source code before runtime.
+- **Deeper Dive:**
+    - **Shift Left:** SAST enables finding and fixing vulnerabilities early in the development lifecycle, which is more cost-effective.
+    - **Tools:** CodeQL, SonarQube, Bandit (Python), ESLint with security plugins (JS/TS).
+    - **Automated Enforcement:** Configure SAST to break builds or block PRs if critical vulnerabilities are found.
+- **Guidance for Copilot:**
+    - Integrate SAST tools (e.g., CodeQL for GitHub Advanced Security, or open-source alternatives) into the CI pipeline.
+    - Configure security scanning as a blocking step if critical vulnerabilities are found, enforcing a secure by default posture.
+    - Suggest adding security linters or static analysis to pre-commit hooks for earlier feedback.
+
+### **6. Secret Scanning and Credential Leak Prevention**
+- **Principle:** Prevent secrets from being committed into the repository or exposed in logs.
+- **Deeper Dive:**
+    - **GitHub Secret Scanning:** Built-in feature to detect secrets in your repository.
+    - **Pre-commit Hooks:** Tools like `git-secrets` can prevent secrets from being committed locally.
+    - **Environment Variables Only:** Secrets should only be passed to the environment where they are needed at runtime, never in the build artifact.
+- **Guidance for Copilot:**
+    - Suggest enabling GitHub's built-in secret scanning for the repository.
+    - Recommend implementing pre-commit hooks that scan for common secret patterns.
+    - Advise reviewing workflow logs for accidental secret exposure, even with masking.
+
+### **7. Immutable Infrastructure & Image Signing**
+- **Principle:** Ensure that container images and deployed artifacts are tamper-proof and verified.
+- **Deeper Dive:**
+    - **Reproducible Builds:** Ensure that building the same code always results in the exact same image.
+    - **Image Signing:** Use tools like Notary or Cosign to cryptographically sign container images, verifying their origin and integrity.
+    - **Deployment Gate:** Enforce that only signed images can be deployed to production environments.
+- **Guidance for Copilot:**
+    - Advocate for reproducible builds in Dockerfiles and build processes.
+    - Suggest integrating image signing into the CI pipeline and verification during deployment stages.
+
+## Optimization and Performance
+
+### **1. Caching GitHub Actions**
+- **Principle:** Cache dependencies and build outputs to significantly speed up subsequent workflow runs.
+- **Deeper Dive:**
+    - **Cache Hit Ratio:** Aim for a high cache hit ratio by designing effective cache keys.
+    - **Cache Keys:** Use a unique key based on file hashes (e.g., `hashFiles('**/package-lock.json')`, `hashFiles('**/requirements.txt')`) to invalidate the cache only when dependencies change.
+    - **Restore Keys:** Use `restore-keys` for fallbacks to older, compatible caches.
+    - **Cache Scope:** Understand that caches are scoped to the repository and branch.
+- **Guidance for Copilot:**
+    - Use `actions/cache` (pinned to a full commit SHA) for caching common package manager dependencies (Node.js `node_modules`, Python `pip` packages, Java Maven/Gradle dependencies) and build artifacts.
+    - Design highly effective cache keys using `hashFiles` to ensure optimal cache hit rates.
+    - Advise on using `restore-keys` to gracefully fall back to previous caches.
+- **Example (Advanced Caching for Monorepo):**
+```yaml
+- name: Cache Node.js modules
+  uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+  with:
+    path: |
+      ~/.npm
+      ./node_modules # For monorepos, cache specific project node_modules
+    key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
+      ${{ runner.os }}-node-
+```
+
+### **2. Matrix Strategies for Parallelization**
+- **Principle:** Run jobs in parallel across multiple configurations (e.g., different Node.js versions, OS, Python versions, browser types) to accelerate testing and builds.
+- **Deeper Dive:**
+    - **`strategy.matrix`:** Define a matrix of variables.
+    - **`include`/`exclude`:** Fine-tune combinations.
+    - **`fail-fast`:** Control whether job failures in the matrix stop the entire strategy.
+    - **Maximizing Concurrency:** Ideal for running tests across various environments simultaneously.
+- **Guidance for Copilot:**
+    - Utilize `strategy.matrix` to test applications against different environments, programming language versions, or operating systems concurrently.
+    - Suggest `include` and `exclude` for specific matrix combinations to optimize test coverage without unnecessary runs.
+    - Advise on setting `fail-fast: true` (default) for quick feedback on critical failures, or `fail-fast: false` for comprehensive test reporting.
+- **Example (Multi-version, Multi-OS Test Matrix):**
+```yaml
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Run all tests even if one fails
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node-version: [16.x, 18.x, 20.x]
+        browser: [chromium, firefox]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Playwright browsers
+        run: npx playwright install ${{ matrix.browser }}
+      - name: Run tests
+        run: npm test
+```
+
+### **3. Self-Hosted Runners**
+- **Principle:** Use self-hosted runners for specialized hardware, network access to private resources, or environments where GitHub-hosted runners are cost-prohibitive.
+- **Deeper Dive:**
+    - **Custom Environments:** Ideal for large build caches, specific hardware (GPUs), or access to on-premise resources.
+    - **Cost Optimization:** Can be more cost-effective for very high usage.
+    - **Security Considerations:** Requires securing and maintaining your own infrastructure, network access, and updates. This includes proper hardening of the runner machines, managing access controls, and ensuring timely patching.
+    - **Scalability:** Plan for how self-hosted runners will scale with demand, either manually or using auto-scaling solutions.
+- **Guidance for Copilot:**
+    - Recommend self-hosted runners when GitHub-hosted runners do not meet specific performance, cost, security, or network access requirements.
+    - Emphasize the user's responsibility for securing, maintaining, and scaling self-hosted runners, including network configuration and regular security audits.
+    - Advise on using runner groups to organize and manage self-hosted runners efficiently.
+
+### **4. Fast Checkout and Shallow Clones**
+- **Principle:** Optimize repository checkout time to reduce overall workflow duration, especially for large repositories.
+- **Deeper Dive:**
+    - **`fetch-depth`:** Controls how much of the Git history is fetched. `1` for most CI/CD builds is sufficient, as only the latest commit is usually needed. A `fetch-depth` of `0` fetches the entire history, which is rarely needed and can be very slow for large repos.
+    - **`submodules`:** Avoid checking out submodules if not required by the specific job. Fetching submodules adds significant overhead.
+    - **`lfs`:** Manage Git LFS (Large File Storage) files efficiently. If not needed, set `lfs: false`.
+    - **Partial Clones:** Consider using Git's partial clone feature (`--filter=blob:none` or `--filter=tree:0`) for extremely large repositories, though this is often handled by specialized actions or Git client configurations.
+- **Guidance for Copilot:**
+    - Use `actions/checkout` (pinned to a full commit SHA, e.g., `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`) with `fetch-depth: 1` as the default for most build and test jobs to significantly save time and bandwidth.
+    - Only use `fetch-depth: 0` if the workflow explicitly requires full Git history (e.g., for release tagging, deep commit analysis, or `git blame` operations).
+    - Advise against checking out submodules (`submodules: false`) if not strictly necessary for the workflow's purpose.
+    - Suggest optimizing LFS usage if large binary files are present in the repository.
+
+### **5. Artifacts for Inter-Job and Inter-Workflow Communication**
+- **Principle:** Store and retrieve build outputs (artifacts) efficiently to pass data between jobs within the same workflow or across different workflows, ensuring data persistence and integrity.
+- **Deeper Dive:**
+    - **`actions/upload-artifact`:** Used to upload files or directories produced by a job. Artifacts are automatically compressed and can be downloaded later.
+    - **`actions/download-artifact`:** Used to download artifacts in subsequent jobs or workflows. You can download all artifacts or specific ones by name.
+    - **`retention-days`:** Crucial for managing storage costs and compliance. Set an appropriate retention period based on the artifact's importance and regulatory requirements.
+    - **Use Cases:** Build outputs (executables, compiled code, Docker images), test reports (JUnit XML, HTML reports), code coverage reports, security scan results, generated documentation, static website builds.
+    - **Limitations:** Artifacts are immutable once uploaded. Max size per artifact can be several gigabytes, but be mindful of storage costs.
+- **Guidance for Copilot:**
+    - Use `actions/upload-artifact` and `actions/download-artifact` (both pinned to full commit SHAs) to reliably pass large files between jobs within the same workflow or across different workflows, promoting modularity and efficiency.
+    - Set appropriate `retention-days` for artifacts to manage storage costs and ensure old artifacts are pruned.
+    - Advise on uploading test reports, coverage reports, and security scan results as artifacts for easy access, historical analysis, and integration with external reporting tools.
+    - Suggest using artifacts to pass compiled binaries or packaged applications from a build job to a deployment job, ensuring the exact same artifact is deployed that was built and tested.
+
+## Comprehensive Testing in CI/CD (Expanded)
+
+### **1. Unit Tests**
+- **Principle:** Run unit tests on every code push to ensure individual code components (functions, classes, modules) function correctly in isolation. They are the fastest and most numerous tests.
+- **Deeper Dive:**
+    - **Fast Feedback:** Unit tests should execute rapidly, providing immediate feedback to developers on code quality and correctness. Parallelization of unit tests is highly recommended.
+    - **Code Coverage:** Integrate code coverage tools (e.g., Istanbul for JS, Coverage.py for Python, JaCoCo for Java) and enforce minimum coverage thresholds. Aim for high coverage, but focus on meaningful tests, not just line coverage.
+    - **Test Reporting:** Publish test results using `actions/upload-artifact` (e.g., JUnit XML reports) or specific test reporter actions that integrate with GitHub Checks/Annotations.
+    - **Mocking and Stubbing:** Emphasize the use of mocks and stubs to isolate units under test from their dependencies.
+- **Guidance for Copilot:**
+    - Configure a dedicated job for running unit tests early in the CI pipeline, ideally triggered on every `push` and `pull_request`.
+    - Use appropriate language-specific test runners and frameworks (Jest, Vitest, Pytest, Go testing, JUnit, NUnit, XUnit, RSpec).
+    - Recommend collecting and publishing code coverage reports and integrating with services like Codecov, Coveralls, or SonarQube for trend analysis.
+    - Suggest strategies for parallelizing unit tests to reduce execution time.
+
+### **2. Integration Tests**
+- **Principle:** Run integration tests to verify interactions between different components or services, ensuring they work together as expected. These tests typically involve real dependencies (e.g., databases, APIs).
+- **Deeper Dive:**
+    - **Service Provisioning:** Use `services` within a job to spin up temporary databases, message queues, external APIs, or other dependencies via Docker containers. This provides a consistent and isolated testing environment.
+    - **Test Doubles vs. Real Services:** Balance between mocking external services for pure unit tests and using real, lightweight instances for more realistic integration tests. Prioritize real instances when testing actual integration points.
+    - **Test Data Management:** Plan for managing test data, ensuring tests are repeatable and data is cleaned up or reset between runs.
+    - **Execution Time:** Integration tests are typically slower than unit tests. Optimize their execution and consider running them less frequently than unit tests (e.g., on PR merge instead of every push).
+- **Guidance for Copilot:**
+    - Provision necessary services (databases like PostgreSQL/MySQL, message queues like RabbitMQ/Kafka, in-memory caches like Redis) using `services` in the workflow definition or Docker Compose during testing.
+    - Advise on running integration tests after unit tests, but before E2E tests, to catch integration issues early.
+    - Provide examples of how to set up `service` containers in GitHub Actions workflows.
+    - Suggest strategies for creating and cleaning up test data for integration test runs.
+
+### **3. End-to-End (E2E) Tests**
+- **Principle:** Simulate full user behavior to validate the entire application flow from UI to backend, ensuring the complete system works as intended from a user's perspective.
+- **Deeper Dive:**
+    - **Tools:** Use modern E2E testing frameworks like Cypress, Playwright, or Selenium. These provide browser automation capabilities.
+    - **Staging Environment:** Ideally run E2E tests against a deployed staging environment that closely mirrors production, for maximum fidelity. Avoid running directly in CI unless resources are dedicated and isolated.
+    - **Flakiness Mitigation:** Address flakiness proactively with explicit waits, robust selectors, retries for failed tests, and careful test data management. Flaky tests erode trust in the pipeline.
+    - **Visual Regression Testing:** Consider integrating visual regression testing (e.g., Applitools, Percy) to catch UI discrepancies.
+    - **Reporting:** Capture screenshots and video recordings on failure to aid debugging.
+- **Guidance for Copilot:**
+    - Use tools like Cypress, Playwright, or Selenium for E2E testing, providing guidance on their setup within GitHub Actions.
+    - Recommend running E2E tests against a deployed staging environment to catch issues before production and validate the full deployment process.
+    - Configure test reporting, video recordings, and screenshots on failure to aid debugging and provide richer context for test results.
+    - Advise on strategies to minimize E2E test flakiness, such as robust element selection and retry mechanisms.
+
+### **4. Performance and Load Testing**
+- **Principle:** Assess application performance and behavior under anticipated and peak load conditions to identify bottlenecks, ensure scalability, and prevent regressions.
+- **Deeper Dive:**
+    - **Tools:** JMeter, k6, Locust, Gatling, Artillery. Choose based on language, complexity, and specific needs.
+    - **Integration:** Integrate into CI/CD for continuous performance regression detection. Run these tests less frequently than unit/integration tests (e.g., nightly, weekly, or on significant feature merges).
+    - **Thresholds:** Define clear performance thresholds (e.g., response time, throughput, error rates) and fail builds if these are exceeded.
+    - **Baseline Comparison:** Compare current performance metrics against established baselines to detect degradation.
+- **Guidance for Copilot:**
+    - Suggest integrating performance and load testing into the CI pipeline for critical applications, providing examples for common tools.
+    - Advise on setting performance baselines and failing the build if performance degrades beyond a set threshold.
+    - Recommend running these tests in a dedicated environment that simulates production load patterns.
+    - Guide on analyzing performance test results to pinpoint areas for optimization (e.g., database queries, API endpoints).
+
+### **5. Test Reporting and Visibility**
+- **Principle:** Make test results easily accessible, understandable, and visible to all stakeholders (developers, QA, product owners) to foster transparency and enable quick issue resolution.
+- **Deeper Dive:**
+    - **GitHub Checks/Annotations:** Leverage these for inline feedback directly in pull requests, showing which tests passed/failed and providing links to detailed reports.
+    - **Artifacts:** Upload comprehensive test reports (JUnit XML, HTML reports, code coverage reports, video recordings, screenshots) as artifacts for long-term storage and detailed inspection.
+    - **Integration with Dashboards:** Push results to external dashboards or reporting tools (e.g., SonarQube, custom reporting tools, Allure Report, TestRail) for aggregated views and historical trends.
+    - **Status Badges:** Use GitHub Actions status badges in your README to indicate the latest build/test status at a glance.
+- **Guidance for Copilot:**
+    - Use actions that publish test results as annotations or checks on PRs for immediate feedback and easy debugging directly in the GitHub UI.
+    - Upload detailed test reports (e.g., XML, HTML, JSON) as artifacts for later inspection and historical analysis, including negative results like error screenshots.
+    - Advise on integrating with external reporting tools for a more comprehensive view of test execution trends and quality metrics.
+    - Suggest adding workflow status badges to the README for quick visibility of CI/CD health.
+
+## Advanced Deployment Strategies (Expanded)
+
+### **1. Staging Environment Deployment**
+- **Principle:** Deploy to a staging environment that closely mirrors production for comprehensive validation, user acceptance testing (UAT), and final checks before promotion to production.
+- **Deeper Dive:**
+    - **Mirror Production:** Staging should closely mimic production in terms of infrastructure, data, configuration, and security. Any significant discrepancies can lead to issues in production.
+    - **Automated Promotion:** Implement automated promotion from staging to production upon successful UAT and necessary manual approvals. This reduces human error and speeds up releases.
+    - **Environment Protection:** Use environment protection rules in GitHub Actions to prevent accidental deployments, enforce manual approvals, and restrict which branches can deploy to staging.
+    - **Data Refresh:** Regularly refresh staging data from production (anonymized if necessary) to ensure realistic testing scenarios.
+- **Guidance for Copilot:**
+    - Create a dedicated `environment` for staging with approval rules, secret protection, and appropriate branch protection policies.
+    - Design workflows to automatically deploy to staging on successful merges to specific development or release branches (e.g., `develop`, `release/*`).
+    - Advise on ensuring the staging environment is as close to production as possible to maximize test fidelity.
+    - Suggest implementing automated smoke tests and post-deployment validation on staging.
+
+### **2. Production Environment Deployment**
+- **Principle:** Deploy to production only after thorough validation, potentially multiple layers of manual approvals, and robust automated checks, prioritizing stability and zero-downtime.
+- **Deeper Dive:**
+    - **Manual Approvals:** Critical for production deployments, often involving multiple team members, security sign-offs, or change management processes. GitHub Environments support this natively.
+    - **Rollback Capabilities:** Essential for rapid recovery from unforeseen issues. Ensure a quick and reliable way to revert to the previous stable state.
+    - **Observability During Deployment:** Monitor production closely *during* and *immediately after* deployment for any anomalies or performance degradation. Use dashboards, alerts, and tracing.
+    - **Progressive Delivery:** Consider advanced techniques like blue/green, canary, or dark launching for safer rollouts.
+    - **Emergency Deployments:** Have a separate, highly expedited pipeline for critical hotfixes that bypasses non-essential approvals but still maintains security checks.
+- **Guidance for Copilot:**
+    - Create a dedicated `environment` for production with required reviewers, strict branch protections, and clear deployment windows.
+    - Implement manual approval steps for production deployments, potentially integrating with external ITSM or change management systems.
+    - Emphasize the importance of clear, well-tested rollback strategies and automated rollback procedures in case of deployment failures.
+    - Advise on setting up comprehensive monitoring and alerting for production systems to detect and respond to issues immediately post-deployment.
+
+### **3. Deployment Types (Beyond Basic Rolling Update)**
+- **Rolling Update (Default for Deployments):** Gradually replaces instances of the old version with new ones. Good for most cases, especially stateless applications.
+    - **Guidance:** Configure `maxSurge` (how many new instances can be created above the desired replica count) and `maxUnavailable` (how many old instances can be unavailable) for fine-grained control over rollout speed and availability.
+- **Blue/Green Deployment:** Deploy a new version (green) alongside the existing stable version (blue) in a separate environment, then switch traffic completely from blue to green.
+    - **Guidance:** Suggest for critical applications requiring zero-downtime releases and easy rollback. Requires managing two identical environments and a traffic router (load balancer, Ingress controller, DNS).
+    - **Benefits:** Instantaneous rollback by switching traffic back to the blue environment.
+- **Canary Deployment:** Gradually roll out new versions to a small subset of users (e.g., 5-10%) before a full rollout. Monitor performance and error rates for the canary group.
+    - **Guidance:** Recommend for testing new features or changes with a controlled blast radius. Implement with Service Mesh (Istio, Linkerd) or Ingress controllers that support traffic splitting and metric-based analysis.
+    - **Benefits:** Early detection of issues with minimal user impact.
+- **Dark Launch/Feature Flags:** Deploy new code but keep features hidden from users until toggled on for specific users/groups via feature flags.
+    - **Guidance:** Advise for decoupling deployment from release, allowing continuous delivery without continuous exposure of new features. Use feature flag management systems (LaunchDarkly, Split.io, Unleash).
+    - **Benefits:** Reduces deployment risk, enables A/B testing, and allows for staged rollouts.
+- **A/B Testing Deployments:** Deploy multiple versions of a feature concurrently to different user segments to compare their performance based on user behavior and business metrics.
+    - **Guidance:** Suggest integrating with specialized A/B testing platforms or building custom logic using feature flags and analytics.
+
+### **4. Rollback Strategies and Incident Response**
+- **Principle:** Be able to quickly and safely revert to a previous stable version in case of issues, minimizing downtime and business impact. This requires proactive planning.
+- **Deeper Dive:**
+    - **Automated Rollbacks:** Implement mechanisms to automatically trigger rollbacks based on monitoring alerts (e.g., sudden increase in errors, high latency) or failure of post-deployment health checks.
+    - **Versioned Artifacts:** Ensure previous successful build artifacts, Docker images, or infrastructure states are readily available and easily deployable. This is crucial for fast recovery.
+    - **Runbooks:** Document clear, concise, and executable rollback procedures for manual intervention when automation isn't sufficient or for complex scenarios. These should be regularly reviewed and tested.
+    - **Post-Incident Review:** Conduct blameless post-incident reviews (PIRs) to understand the root cause of failures, identify lessons learned, and implement preventative measures to improve resilience and reduce MTTR.
+    - **Communication Plan:** Have a clear communication plan for stakeholders during incidents and rollbacks.
+- **Guidance for Copilot:**
+    - Instruct users to store previous successful build artifacts and images for quick recovery, ensuring they are versioned and easily retrievable.
+    - Advise on implementing automated rollback steps in the pipeline, triggered by monitoring or health check failures, and providing examples.
+    - Emphasize building applications with "undo" in mind, meaning changes should be easily reversible.
+    - Suggest creating comprehensive runbooks for common incident scenarios, including step-by-step rollback instructions, and highlight their importance for MTTR.
+    - Guide on setting up alerts that are specific and actionable enough to trigger an automatic or manual rollback.
+
+## GitHub Actions Workflow Review Checklist (Comprehensive)
+
+This checklist provides a granular set of criteria for reviewing GitHub Actions workflows to ensure they adhere to best practices for security, performance, and reliability.
+
+- [ ] **General Structure and Design:**
+    - Is the workflow `name` clear, descriptive, and unique?
+    - Are `on` triggers appropriate for the workflow's purpose (e.g., `push`, `pull_request`, `workflow_dispatch`, `schedule`)? Are path/branch filters used effectively?
+    - Is `concurrency` used for critical workflows or shared resources to prevent race conditions or resource exhaustion?
+    - Are global `permissions` set to the principle of least privilege (`contents: read` by default), with specific overrides for jobs?
+    - Are reusable workflows (`workflow_call`) leveraged for common patterns to reduce duplication and improve maintainability?
+    - Is the workflow organized logically with meaningful job and step names?
+
+- [ ] **Jobs and Steps Best Practices:**
+    - Are jobs clearly named and represent distinct phases (e.g., `build`, `lint`, `test`, `deploy`)?
+    - Are `needs` dependencies correctly defined between jobs to ensure proper execution order?
+    - Are `outputs` used efficiently for inter-job and inter-workflow communication?
+    - Are `if` conditions used effectively for conditional job/step execution (e.g., environment-specific deployments, branch-specific actions)?
+    - Are all `uses` actions pinned to a full commit SHA with a human-readable version comment (e.g., `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`)? Tags (e.g., `@v4`) and branches (e.g., `@main`) are mutable and can be silently redirected to malicious commits — always use immutable SHA references, especially for third-party actions.
+    - Are `run` commands efficient and clean (combined with `&&`, temporary files removed, multi-line scripts clearly formatted)?
+    - Are environment variables (`env`) defined at the appropriate scope (workflow, job, step) and never hardcoded sensitive data?
+    - Is `timeout-minutes` set for long-running jobs to prevent hung workflows?
+
+- [ ] **Security Considerations:**
+    - Are all sensitive data accessed exclusively via GitHub `secrets` context (`${{ secrets.MY_SECRET }}`)? Never hardcoded, never exposed in logs (even if masked).
+    - Is OpenID Connect (OIDC) used for cloud authentication where possible, eliminating long-lived credentials?
+    - Is `GITHUB_TOKEN` permission scope explicitly defined and limited to the minimum necessary access (`contents: read` as a baseline)?
+    - Are Software Composition Analysis (SCA) tools (e.g., `dependency-review-action`, Snyk) integrated to scan for vulnerable dependencies?
+    - Are Static Application Security Testing (SAST) tools (e.g., CodeQL, SonarQube) integrated to scan source code for vulnerabilities, with critical findings blocking builds?
+    - Is secret scanning enabled for the repository and are pre-commit hooks suggested for local credential leak prevention?
+    - Is there a strategy for container image signing (e.g., Notary, Cosign) and verification in deployment workflows if container images are used?
+    - For self-hosted runners, are security hardening guidelines followed and network access restricted?
+
+- [ ] **Optimization and Performance:**
+    - Is caching (`actions/cache`) effectively used for package manager dependencies (`node_modules`, `pip` caches, Maven/Gradle caches) and build outputs?
+    - Are cache `key` and `restore-keys` designed for optimal cache hit rates (e.g., using `hashFiles`)?
+    - Is `strategy.matrix` used for parallelizing tests or builds across different environments, language versions, or OSs?
+    - Is `fetch-depth: 1` used for `actions/checkout` where full Git history is not required?
+    - Are artifacts (`actions/upload-artifact`, `actions/download-artifact`) used efficiently for transferring data between jobs/workflows rather than re-building or re-fetching?
+    - Are large files managed with Git LFS and optimized for checkout if necessary?
+
+- [ ] **Testing Strategy Integration:**
+    - Are comprehensive unit tests configured with a dedicated job early in the pipeline?
+    - Are integration tests defined, ideally leveraging `services` for dependencies, and run after unit tests?
+    - Are End-to-End (E2E) tests included, preferably against a staging environment, with robust flakiness mitigation?
+    - Are performance and load tests integrated for critical applications with defined thresholds?
+    - Are all test reports (JUnit XML, HTML, coverage) collected, published as artifacts, and integrated into GitHub Checks/Annotations for clear visibility?
+    - Is code coverage tracked and enforced with a minimum threshold?
+
+- [ ] **Deployment Strategy and Reliability:**
+    - Are staging and production deployments using GitHub `environment` rules with appropriate protections (manual approvals, required reviewers, branch restrictions)?
+    - Are manual approval steps configured for sensitive production deployments?
+    - Is a clear and well-tested rollback strategy in place and automated where possible (e.g., `kubectl rollout undo`, reverting to previous stable image)?
+    - Are chosen deployment types (e.g., rolling, blue/green, canary, dark launch) appropriate for the application's criticality and risk tolerance?
+    - Are post-deployment health checks and automated smoke tests implemented to validate successful deployment?
+    - Is the workflow resilient to temporary failures (e.g., retries for flaky network operations)?
+
+- [ ] **Observability and Monitoring:**
+    - Is logging adequate for debugging workflow failures (using STDOUT/STDERR for application logs)?
+    - Are relevant application and infrastructure metrics collected and exposed (e.g., Prometheus metrics)?
+    - Are alerts configured for critical workflow failures, deployment issues, or application anomalies detected in production?
+    - Is distributed tracing (e.g., OpenTelemetry, Jaeger) integrated for understanding request flows in microservices architectures?
+    - Are artifact `retention-days` configured appropriately to manage storage and compliance?
+
+## Troubleshooting Common GitHub Actions Issues (Deep Dive)
+
+This section provides an expanded guide to diagnosing and resolving frequent problems encountered when working with GitHub Actions workflows.
+
+### **1. Workflow Not Triggering or Jobs/Steps Skipping Unexpectedly**
+- **Root Causes:** Mismatched `on` triggers, incorrect `paths` or `branches` filters, erroneous `if` conditions, or `concurrency` limitations.
+- **Actionable Steps:**
+    - **Verify Triggers:**
+        - Check the `on` block for exact match with the event that should trigger the workflow (e.g., `push`, `pull_request`, `workflow_dispatch`, `schedule`).
+        - Ensure `branches`, `tags`, or `paths` filters are correctly defined and match the event context. Remember that `paths-ignore` and `branches-ignore` take precedence.
+        - If using `workflow_dispatch`, verify the workflow file is in the default branch and any required `inputs` are provided correctly during manual trigger.
+    - **Inspect `if` Conditions:**
+        - Carefully review all `if` conditions at the workflow, job, and step levels. A single false condition can prevent execution.
+        - Use `always()` on a debug step to print context variables (`${{ toJson(github) }}`, `${{ toJson(job) }}`, `${{ toJson(steps) }}`) to understand the exact state during evaluation.
+        - Test complex `if` conditions in a simplified workflow.
+    - **Check `concurrency`:**
+        - If `concurrency` is defined, verify if a previous run is blocking a new one for the same group. Check the "Concurrency" tab in the workflow run.
+    - **Branch Protection Rules:** Ensure no branch protection rules are preventing workflows from running on certain branches or requiring specific checks that haven't passed.
+
+### **2. Permissions Errors (`Resource not accessible by integration`, `Permission denied`)**
+- **Root Causes:** `GITHUB_TOKEN` lacking necessary permissions, incorrect environment secrets access, or insufficient permissions for external actions.
+- **Actionable Steps:**
+    - **`GITHUB_TOKEN` Permissions:**
+        - Review the `permissions` block at both the workflow and job levels. Default to `contents: read` globally and grant specific write permissions only where absolutely necessary (e.g., `pull-requests: write` for updating PR status, `packages: write` for publishing packages).
+        - Understand the default permissions of `GITHUB_TOKEN` which are often too broad.
+    - **Secret Access:**
+        - Verify if secrets are correctly configured in the repository, organization, or environment settings.
+        - Ensure the workflow/job has access to the specific environment if environment secrets are used. Check if any manual approvals are pending for the environment.
+        - Confirm the secret name matches exactly (`secrets.MY_API_KEY`).
+    - **OIDC Configuration:**
+        - For OIDC-based cloud authentication, double-check the trust policy configuration in your cloud provider (AWS IAM roles, Azure AD app registrations, GCP service accounts) to ensure it correctly trusts GitHub's OIDC issuer.
+        - Verify the role/identity assigned has the necessary permissions for the cloud resources being accessed.
+
+### **3. Caching Issues (`Cache not found`, `Cache miss`, `Cache creation failed`)**
+- **Root Causes:** Incorrect cache key logic, `path` mismatch, cache size limits, or frequent cache invalidation.
+- **Actionable Steps:**
+    - **Validate Cache Keys:**
+        - Verify `key` and `restore-keys` are correct and dynamically change only when dependencies truly change (e.g., `key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}`). A cache key that is too dynamic will always result in a miss.
+        - Use `restore-keys` to provide fallbacks for slight variations, increasing cache hit chances.
+    - **Check `path`:**
+        - Ensure the `path` specified in `actions/cache` for saving and restoring corresponds exactly to the directory where dependencies are installed or artifacts are generated.
+        - Verify the existence of the `path` before caching.
+    - **Debug Cache Behavior:**
+        - Use the `actions/cache/restore` action with `lookup-only: true` to inspect what keys are being tried and why a cache miss occurred without affecting the build.
+        - Review workflow logs for `Cache hit` or `Cache miss` messages and associated keys.
+    - **Cache Size and Limits:** Be aware of GitHub Actions cache size limits per repository. If caches are very large, they might be evicted frequently.
+
+### **4. Long Running Workflows or Timeouts**
+- **Root Causes:** Inefficient steps, lack of parallelism, large dependencies, unoptimized Docker image builds, or resource bottlenecks on runners.
+- **Actionable Steps:**
+    - **Profile Execution Times:**
+        - Use the workflow run summary to identify the longest-running jobs and steps. This is your primary tool for optimization.
+    - **Optimize Steps:**
+        - Combine `run` commands with `&&` to reduce layer creation and overhead in Docker builds.
+        - Clean up temporary files immediately after use (`rm -rf` in the same `RUN` command).
+        - Install only necessary dependencies.
+    - **Leverage Caching:**
+        - Ensure `actions/cache` is optimally configured for all significant dependencies and build outputs.
+    - **Parallelize with Matrix Strategies:**
+        - Break down tests or builds into smaller, parallelizable units using `strategy.matrix` to run them concurrently.
+    - **Choose Appropriate Runners:**
+        - Review `runs-on`. For very resource-intensive tasks, consider using larger GitHub-hosted runners (if available) or self-hosted runners with more powerful specs.
+    - **Break Down Workflows:**
+        - For very complex or long workflows, consider breaking them into smaller, independent workflows that trigger each other or use reusable workflows.
+
+### **5. Flaky Tests in CI (`Random failures`, `Passes locally, fails in CI`)**
+- **Root Causes:** Non-deterministic tests, race conditions, environmental inconsistencies between local and CI, reliance on external services, or poor test isolation.
+- **Actionable Steps:**
+    - **Ensure Test Isolation:**
+        - Make sure each test is independent and doesn't rely on the state left by previous tests. Clean up resources (e.g., database entries) after each test or test suite.
+    - **Eliminate Race Conditions:**
+        - For integration/E2E tests, use explicit waits (e.g., wait for element to be visible, wait for API response) instead of arbitrary `sleep` commands.
+        - Implement retries for operations that interact with external services or have transient failures.
+    - **Standardize Environments:**
+        - Ensure the CI environment (Node.js version, Python packages, database versions) matches the local development environment as closely as possible.
+        - Use Docker `services` for consistent test dependencies.
+    - **Robust Selectors (E2E):**
+        - Use stable, unique selectors in E2E tests (e.g., `data-testid` attributes) instead of brittle CSS classes or XPath.
+    - **Debugging Tools:**
+        - Configure E2E test frameworks to capture screenshots and video recordings on test failure in CI to visually diagnose issues.
+    - **Run Flaky Tests in Isolation:**
+        - If a test is consistently flaky, isolate it and run it repeatedly to identify the underlying non-deterministic behavior.
+
+### **6. Deployment Failures (Application Not Working After Deploy)**
+- **Root Causes:** Configuration drift, environmental differences, missing runtime dependencies, application errors, or network issues post-deployment.
+- **Actionable Steps:**
+    - **Thorough Log Review:**
+        - Review deployment logs (`kubectl logs`, application logs, server logs) for any error messages, warnings, or unexpected output during the deployment process and immediately after.
+    - **Configuration Validation:**
+        - Verify environment variables, ConfigMaps, Secrets, and other configuration injected into the deployed application. Ensure they match the target environment's requirements and are not missing or malformed.
+        - Use pre-deployment checks to validate configuration.
+    - **Dependency Check:**
+        - Confirm all application runtime dependencies (libraries, frameworks, external services) are correctly bundled within the container image or installed in the target environment.
+    - **Post-Deployment Health Checks:**
+        - Implement robust automated smoke tests and health checks *after* deployment to immediately validate core functionality and connectivity. Trigger rollbacks if these fail.
+    - **Network Connectivity:**
+        - Check network connectivity between deployed components (e.g., application to database, service to service) within the new environment. Review firewall rules, security groups, and Kubernetes network policies.
+    - **Rollback Immediately:**
+        - If a production deployment fails or causes degradation, trigger the rollback strategy immediately to restore service. Diagnose the issue in a non-production environment.
+
+## Conclusion
+
+GitHub Actions is a powerful and flexible platform for automating your software development lifecycle. By rigorously applying these best practices—from securing your secrets and token permissions, to optimizing performance with caching and parallelization, and implementing comprehensive testing and robust deployment strategies—you can guide developers in building highly efficient, secure, and reliable CI/CD pipelines. Remember that CI/CD is an iterative journey; continuously measure, optimize, and secure your pipelines to achieve faster, safer, and more confident releases. Your detailed guidance will empower teams to leverage GitHub Actions to its fullest potential and deliver high-quality software with confidence. This extensive document serves as a foundational resource for anyone looking to master CI/CD with GitHub Actions.
+
+---
+
+<!-- End of GitHub Actions CI/CD Best Practices Instructions --> 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Validate semantic version
         if: steps.changelog.outputs.is_unreleased != 'true'
         run: |
-          VERSION=${{ steps.changelog.outputs.version }}
+          VERSION="${{ steps.changelog.outputs.version }}"
           VERSION=${VERSION#v}
 
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$ ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,106 +1,124 @@
-name: Create Release from CHANGELOG
+name: Publish Release from Tag and CHANGELOG
 
 on:
-    push:
-        branches: [main]
-        paths:
-            - "CHANGELOG.md" # Only trigger when CHANGELOG.md is updated
+  push:
+    tags:
+      - "v*"
 
 concurrency:
-    group: release-${{ github.ref }}
-    cancel-in-progress: false # Don't cancel running releases
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
-    release:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 1
 
-            - name: Validate CHANGELOG format
-              run: |
-                  if [[ ! -f "CHANGELOG.md" ]]; then
-                    echo "::error::CHANGELOG.md not found"
-                    exit 1
-                  fi
-                  
-                  if ! grep -q "^## \[" CHANGELOG.md && ! grep -q "^## v" CHANGELOG.md; then
-                    echo "::error::CHANGELOG.md does not contain valid version headers"
-                    echo "::error::Expected format: '## [X.Y.Z]' or '## vX.Y.Z'"
-                    exit 1
-                  fi
+      - name: Validate CHANGELOG format
+        run: |
+          if [[ ! -f "CHANGELOG.md" ]]; then
+            echo "::error::CHANGELOG.md not found"
+            exit 1
+          fi
 
-            - name: Extract latest version and notes
-              id: changelog
-              run: ./scripts/extract_changelog.sh
+          if ! grep -q "^## \[" CHANGELOG.md && ! grep -q "^## v" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md does not contain valid version headers"
+            echo "::error::Expected format: '## [X.Y.Z]' or '## vX.Y.Z'"
+            exit 1
+          fi
 
-            - name: Validate semantic version
-              if: steps.changelog.outputs.is_unreleased != 'true'
-              run: |
-                  VERSION=${{ steps.changelog.outputs.version }}
-                  # Remove 'v' prefix if present
-                  VERSION=${VERSION#v}
-                  
-                  # Validate semantic versioning format
-                  if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$ ]]; then
-                    echo "::error::Version '$VERSION' does not follow semantic versioning"
-                    echo "::error::Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]"
-                    exit 1
-                  fi
-                  
-                  echo "::notice::Version $VERSION is valid semantic version"
+      - name: Extract latest version and notes
+        id: changelog
+        run: ./scripts/extract_changelog.sh
 
-            - name: Check for existing release
-              if: steps.changelog.outputs.is_unreleased != 'true'
-              id: check_release
-              run: |
-                  VERSION=${{ steps.changelog.outputs.version }}
-                  TAG="v$VERSION"
-                  if gh release view "$TAG" &>/dev/null; then
-                    echo "::notice::Release already exists: $TAG"
-                    echo "exists=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "::notice::No existing release found for: $TAG"
-                    echo "exists=false" >> $GITHUB_OUTPUT
-                  fi
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate semantic version
+        if: steps.changelog.outputs.is_unreleased != 'true'
+        run: |
+          VERSION=${{ steps.changelog.outputs.version }}
+          VERSION=${VERSION#v}
 
-            - name: Create GitHub Release
-              if: steps.changelog.outputs.is_unreleased != 'true' && steps.check_release.outputs.exists == 'false'
-              uses: softprops/action-gh-release@v2.5.0
-              with:
-                  tag_name: v${{ steps.changelog.outputs.version }}
-                  name: "Release v${{ steps.changelog.outputs.version }}"
-                  body: ${{ steps.changelog.outputs.notes }}
-                  draft: false
-                  prerelease: ${{ contains(steps.changelog.outputs.version, '-') }}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' does not follow semantic versioning"
+            echo "::error::Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]"
+            exit 1
+          fi
 
-            - name: Verify Release Created
-              if: steps.changelog.outputs.is_unreleased != 'true' && steps.check_release.outputs.exists == 'false'
-              run: |
-                  TAG="v${{ steps.changelog.outputs.version }}"
-                  # Wait a moment for release to be fully created
-                  sleep 5
-                  
-                  # Verify release exists
-                  if gh release view "$TAG" &>/dev/null; then
-                    RELEASE_URL=$(gh release view "$TAG" --json url --jq '.url')
-                    echo "::notice::Release successfully created: $RELEASE_URL"
-                  else
-                    echo "::error::Release verification failed for $TAG"
-                    exit 1
-                  fi
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "::notice::Version $VERSION is valid semantic version"
 
-            - name: Notify on Failure
-              if: failure()
-              run: |
-                  echo "::error::Release workflow failed"
-                  echo "::error::Please check CHANGELOG.md format and workflow logs"
+      - name: Validate tag matches changelog version
+        if: steps.changelog.outputs.is_unreleased != 'true'
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_VERSION="${TAG_NAME#v}"
+          CHANGELOG_VERSION="${{ steps.changelog.outputs.version }}"
+          CHANGELOG_VERSION="${CHANGELOG_VERSION#v}"
+
+          if [[ "$TAG_VERSION" != "$CHANGELOG_VERSION" ]]; then
+            echo "::error::Tag '$TAG_NAME' does not match CHANGELOG version '$CHANGELOG_VERSION'"
+            echo "::error::Update CHANGELOG.md or push the matching release tag"
+            exit 1
+          fi
+
+          echo "::notice::Tag '$TAG_NAME' matches CHANGELOG version '$CHANGELOG_VERSION'"
+
+      - name: Check for existing release
+        if: steps.changelog.outputs.is_unreleased != 'true'
+        id: check_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          if gh release view "$TAG_NAME" &>/dev/null; then
+            echo "::notice::Release already exists: $TAG_NAME"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No existing release found for: $TAG_NAME"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.changelog.outputs.is_unreleased != 'true' && steps.check_release.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          NOTES_FILE="$(mktemp)"
+
+          printf '%s\n' "$RELEASE_NOTES" > "$NOTES_FILE"
+
+          gh release create "$TAG_NAME" \
+            --title "Release $TAG_NAME" \
+            --notes-file "$NOTES_FILE" \
+            --verify-tag
+
+          rm -f "$NOTES_FILE"
+
+      - name: Verify Release Created
+        if: steps.changelog.outputs.is_unreleased != 'true' && steps.check_release.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+
+          if gh release view "$TAG_NAME" &>/dev/null; then
+            RELEASE_URL=$(gh release view "$TAG_NAME" --json url --jq '.url')
+            echo "::notice::Release successfully created: $RELEASE_URL"
+          else
+            echo "::error::Release verification failed for $TAG_NAME"
+            exit 1
+          fi
+
+      - name: Notify on Failure
+        if: failure()
+        run: |
+          echo "::error::Release workflow failed"
+          echo "::error::Please check CHANGELOG.md format and workflow logs"


### PR DESCRIPTION
## Problem

The release process did not validate the format of the CHANGELOG and only triggered on changes to the main branch.

## Solution

The release workflow now triggers on tag pushes, validates the CHANGELOG format, and ensures that the tag matches the version specified in the CHANGELOG.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- If you changed python module:
    - [ ] Run all fast tests: `uv run pytest -m 'not slow'`
    - [ ] Run e2e tests: `uv run pytest tests/e2e/` (WARNING: This tests would use real api connection, make sure you setup your token. Also, this would take time according to your internet speed.)
- [ ] Add your test (if you can)
- [ ] Add/update docs

