### PR TITLE
fix(verifier): save computed checksum even when verification fails

### DIFF
--- a/src/my_unicorn/core/verification/verification_methods.py
+++ b/src/my_unicorn/core/verification/verification_methods.py
@@ -49,6 +49,7 @@ async def verify_digest(
         MethodResult or None if failed
 
     """
+    actual_digest: str | None = None
     try:
         logger.debug("Attempting digest verification from GitHub API")
         logger.debug("AppImage file: %s", verifier.file_path.name)
@@ -76,6 +77,7 @@ async def verify_digest(
         return MethodResult(
             passed=False,
             hash=digest,
+            computed_hash=actual_digest,
             details=str(e),
         )
 
@@ -224,8 +226,11 @@ async def verify_checksum_file(
         logger.error("Hash mismatch detected")
         return MethodResult(
             passed=False,
-            hash=f"{hash_type}:{computed_hash}",
+            hash=expected_hash,
+            computed_hash=computed_hash,
             details=f"Hash mismatch (expected: {expected_hash})",
+            url=checksum_file.url,
+            hash_type=hash_type,
         )
 
     except Exception as e:

--- a/tests/core/verification/test_verification_methods.py
+++ b/tests/core/verification/test_verification_methods.py
@@ -68,6 +68,9 @@ class TestVerifyDigest:
         assert result is not None
         assert result.passed is False
         assert "Hash mismatch" in result.details
+        # Issue #245: computed hash must be saved even when verification
+        # fails, so users can compare it against the expected digest.
+        assert result.computed_hash == "wrong_hash"
 
         # Case 2: Unsupported algorithm
         mock_verifier.verify_digest.side_effect = Exception(
@@ -266,6 +269,9 @@ class TestVerifyChecksumFile:
         assert result is not None
         assert result.passed is False
         assert "mismatch" in result.details.lower()
+        # Issue #245: computed hash must be saved on failure so users
+        # can compare against the expected value.
+        assert result.computed_hash == "different_wrong_hash"
 
         # Case 2: File not found in checksum file
         mock_verifier.parse_checksum_file.return_value = None


### PR DESCRIPTION
## Problem

Closes #245. When checksum verification fails, the failure paths in `verification_methods.py` constructed `MethodResult` without populating `computed_hash`, so the state config recorded an empty `computed` field and users couldn't compare against the expected value.

## Solution

Pass the computed hash through to `MethodResult` on the digest exception path and the checksum-file mismatch path. Added regression tests asserting `computed_hash` is preserved on failure for both methods.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Run all fast tests: 335 verification-related tests pass; the 28 unrelated failures exist on main as well.
- [x] Add tests