### PR TITLE
fix(progress): dedupe section headers across renders (#294)

### DIFF
--- a/src/my_unicorn/core/progress/ascii_output.py
+++ b/src/my_unicorn/core/progress/ascii_output.py
@@ -73,6 +73,11 @@ class TerminalWriter:
     ) -> tuple[list[str], set[str]]:
         """Parse output and find sections not in known_sections.
 
+        Sections are deduplicated by both full content and header line
+        (the first non-empty line). Header-line dedup prevents repeated
+        headers like "Fetching from API:" from being printed for every
+        progress update in non-interactive mode (issue #294).
+
         Args:
             output: Output string containing sections separated by blank lines
             known_sections: Set of section signatures already written
@@ -81,15 +86,26 @@ class TerminalWriter:
             Tuple of (new_sections_list, new_signatures_set)
 
         """
+        known_headers = {
+            sig.split("\n", 1)[0] for sig in known_sections if sig
+        }
+
         sections = output.split("\n\n")
         new_sections: list[str] = []
         new_signatures: set[str] = set()
 
         for section in sections:
             section_sig = section.strip()
-            if section_sig and section_sig not in known_sections:
-                new_sections.append(section)
-                new_signatures.add(section_sig)
+            if not section_sig or section_sig in known_sections:
+                continue
+
+            header = section_sig.split("\n", 1)[0]
+            if header in known_headers:
+                continue
+
+            new_sections.append(section)
+            new_signatures.add(section_sig)
+            known_headers.add(header)
 
         return new_sections, new_signatures
 

--- a/tests/core/progress/test_ascii_output.py
+++ b/tests/core/progress/test_ascii_output.py
@@ -323,3 +323,32 @@ class TestWriteNoninteractive:
         sections = writer.write_noninteractive("   \n\n   ")
 
         assert sections == set()
+
+    def test_write_noninteractive_dedup_header_across_progress(self) -> None:
+        """Repeated section headers must not be reprinted as progress changes.
+
+        Regression test for #294: when the same section (e.g.,
+        "Fetching from API:") emits different content lines as progress
+        advances, the header should appear at most once instead of
+        printing "Fetching from API:" twice.
+        """
+        output = io.StringIO()
+        writer = TerminalWriter(output, interactive=False)
+
+        # First render: API task in progress. Mirror the call site in
+        # render_once which folds returned signatures into the writer's
+        # _written_sections set after each write.
+        first = writer.write_noninteractive(
+            "Fetching from API:\nGitHub Releases    1/2 Fetching..."
+        )
+        writer._written_sections.update(first)
+
+        # Second render: same task with updated progress -> header
+        # would otherwise be reprinted because the full signature
+        # differs.
+        sections = writer.write_noninteractive(
+            "Fetching from API:\nGitHub Releases    2/2 Retrieved from cache"
+        )
+
+        assert sections == set()
+        assert output.getvalue().count("Fetching from API:") == 1


### PR DESCRIPTION
Fixes #294. In non-interactive mode, the API fetch section was reprinted whenever its progress changed, so users saw `Fetching from API:` twice during `--update-outdated`. `_find_new_sections` now skips a new section when its header line was already written, keeping each header (`Fetching from API:`, `Downloading:`, `Processing:`) at most once per session.