### PR TITLE
fix(ui): resolve error display issue in API section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed autocomplete.bash script wrong dry-run implementation.
 - Fixed refresh cache flag updates the caches by requesting from the API again, but the GitHub releases section seems not to update itself (#259 by @SAY-5 in #315)
+- Fixed ui duplication in api section of update command. (#294)
 
 ### Removed
 
@@ -984,6 +985,9 @@ Please change your current configuration files to the new format. The new format
 - refactor: improve better error handling on verify.py
 - chore: add copilot instructions
 
+[2.5.2-alpha]: https://github.com/Cyber-Syntax/my-unicorn/compare/v2.5.1-alpha...v2.5.2-alpha
+[2.5.1-alpha]: https://github.com/Cyber-Syntax/my-unicorn/compare/v2.5.0-alpha...v2.5.1-alpha
+[2.5.0-alpha]: https://github.com/Cyber-Syntax/my-unicorn/compare/v2.4.3-alpha...v2.5.0-alpha
 [2.4.4-alpha]: https://github.com/Cyber-Syntax/my-unicorn/compare/v2.4.3-alpha...v2.4.4-alpha
 [2.4.3-alpha]: https://github.com/Cyber-Syntax/my-unicorn/compare/v2.4.2-alpha...v2.4.3-alpha
 [2.4.2-alpha]: https://github.com/Cyber-Syntax/my-unicorn/compare/v2.4.1-alpha...v2.4.2-alpha

--- a/src/my_unicorn/core/install.py
+++ b/src/my_unicorn/core/install.py
@@ -126,7 +126,7 @@ def _print_statistics(categories: dict[str, list]) -> None:
     """Print final installation statistics."""
     if categories["newly_installed"]:
         count = len(categories["newly_installed"])
-        logger.info("🎉 Successfully installed %s app(s)", count)
+        logger.info("\n🎉 Successfully installed %s app(s)", count)
     if categories["with_warnings"]:
         count = len(categories["with_warnings"])
         logger.warning("⚠️  %s app(s) installed with warnings", count)

--- a/src/my_unicorn/core/update.py
+++ b/src/my_unicorn/core/update.py
@@ -1489,8 +1489,10 @@ def display_update_results(results: dict) -> None:  # noqa: C901, PLR0912
         for app_name in failed:
             app_info = _find_update_info(app_name, update_infos)
             logger.info("%-25s ❌ Update failed", app_name)
+            # Keep error reason indented under the app name
+            # app name is already shown in the log line above
             if app_info.error_reason:
-                logger.info("%25s    → %s", app_name, app_info.error_reason)
+                logger.info("%25s    → %s", "", app_info.error_reason)
 
         # Show up-to-date apps
         for app_name in up_to_date:

--- a/src/my_unicorn/core/update.py
+++ b/src/my_unicorn/core/update.py
@@ -1020,11 +1020,14 @@ def select_asset_for_update(
     )
 
     if not appimage_asset:
-        logger.error("No AppImage found for %s", app_name)
-        return (
-            None,
-            "AppImage not found in release - may still be building",
+        # use debug level to avoid duplicate `Fetching from API:` log messages.
+        # see #294
+        #
+        # user can still see the no appimage error in the summary section.
+        logger.debug(
+            "No AppImage found for %s, may still be building", app_name
         )
+        return None, "AppImage not found in release - may still be building"
 
     return appimage_asset, None
 

--- a/src/my_unicorn/core/update.py
+++ b/src/my_unicorn/core/update.py
@@ -1196,181 +1196,6 @@ class CatalogCache:
         self._cache.clear()
 
 
-def display_update_summary(
-    updated_apps: list[str],
-    failed_apps: list[str],
-    up_to_date_apps: list[str],  # noqa: ARG001
-    update_infos: list[UpdateInfo],
-    check_only: bool = False,  # noqa: FBT001, FBT002
-) -> None:
-    """Display a comprehensive summary of update results.
-
-    Args:
-        updated_apps: List of successfully updated app names.
-        failed_apps: List of failed app names.
-        up_to_date_apps: List of apps that are up to date.
-        update_infos: List of UpdateInfo objects with details.
-        check_only: If True, display check-only summary instead of
-            update summary.
-
-    """
-    if not update_infos:
-        logger.warning("No apps to process.")
-        return
-
-    if check_only:
-        _display_check_only_summary(update_infos)
-    else:
-        _display_update_operation_summary(
-            updated_apps, failed_apps, update_infos
-        )
-
-
-def _display_update_operation_summary(
-    updated_apps: list[str],
-    failed_apps: list[str],
-    update_infos: list[UpdateInfo],
-) -> None:
-    """Display summary for actual update operations.
-
-    Args:
-        updated_apps: List of successfully updated app names.
-        failed_apps: List of failed app names.
-        update_infos: List of UpdateInfo objects with details.
-
-    """
-    logger.info("📦 Update Summary:")
-    logger.info("-" * 50)
-
-    updated_count = len(updated_apps)
-    failed_count = len(failed_apps)
-
-    # Show individual results
-    for app_name in updated_apps:
-        app_info = _find_update_info(app_name, update_infos)
-        version_info = (
-            f"{app_info.current_version} → {app_info.latest_version}"
-        )
-        logger.info("%-25s ✅ %s", app_name, version_info)
-
-    for app_name in failed_apps:
-        app_info = _find_update_info(app_name, update_infos)
-        logger.info("%-25s ❌ Update failed", app_name)
-        # Display error reason if available
-        if app_info.error_reason:
-            logger.info("%25s    → %s", app_name, app_info.error_reason)
-
-    # Show summary stats
-    if updated_count > 0:
-        logger.info("\n🎉 Successfully updated %s app(s)", updated_count)
-    if failed_count > 0:
-        logger.info("❌ %s app(s) failed to update", failed_count)
-
-
-def _display_check_only_summary(update_infos: list[UpdateInfo]) -> None:
-    """Display summary for check-only operations.
-
-    Args:
-        update_infos: List of UpdateInfo objects with details.
-
-    """
-    total_apps = len(update_infos)
-    apps_with_updates = sum(1 for info in update_infos if info.has_update)
-
-    if total_apps == 0:
-        logger.info("No apps to check.")
-        return
-
-    logger.info("\n📋 Check Summary:")
-    logger.info("-" * 50)
-    logger.info("Total apps checked: %s", total_apps)
-    logger.info("Updates available: %s", apps_with_updates)
-    logger.info("Up to date: %s", total_apps - apps_with_updates)
-
-    if apps_with_updates > 0:
-        logger.info("\nApps with updates available:")
-        for info in update_infos:
-            if info.has_update:
-                version_info = (
-                    f"{info.current_version} → {info.latest_version}"
-                )
-                logger.info("  • %s: %s", info.app_name, version_info)
-
-
-def display_update_details(
-    updated_apps: list[str],
-    failed_apps: list[str],
-    update_infos: list[UpdateInfo],
-) -> None:
-    """Display detailed results including version information.
-
-    Args:
-        updated_apps: List of successfully updated app names.
-        failed_apps: List of failed app names.
-        update_infos: List of UpdateInfo objects with details.
-
-    """
-    if not update_infos:
-        logger.info("No update information available.")
-        return
-
-    logger.info("\n📊 Detailed Results:")
-    logger.info("-" * 70)
-    logger.info("%-20s %-20s %-25s", "App Name", "Status", "Version Info")
-    logger.info("-" * 70)
-
-    for info in update_infos:
-        status = _get_update_status(info, updated_apps, failed_apps)
-        version_info = _format_update_version_info(info)
-        logger.info("%-20s %-20s %-25s", info.app_name, status, version_info)
-
-
-def _get_update_status(
-    info: UpdateInfo,
-    updated_apps: list[str],
-    failed_apps: list[str],
-) -> str:
-    """Get the status string for an app.
-
-    Args:
-        info: UpdateInfo for the app.
-        updated_apps: List of successfully updated app names.
-        failed_apps: List of failed app names.
-
-    Returns:
-        Status string for display.
-
-    """
-    if info.app_name in updated_apps:
-        return "✅ Updated"
-    if info.app_name in failed_apps:
-        return "❌ Failed"
-    if info.has_update:
-        return "📦 Update available"
-    return "✅ Up to date"
-
-
-def _format_update_version_info(info: UpdateInfo) -> str:
-    """Format version information for display.
-
-    Args:
-        info: UpdateInfo containing version information.
-
-    Returns:
-        Formatted version string.
-
-    """
-    if info.has_update:
-        version_str = f"{info.current_version} → {info.latest_version}"
-    else:
-        version_str = info.current_version
-
-    # Truncate long version strings
-    if len(version_str) > 40:  # noqa: PLR2004
-        return version_str[:37] + "..."
-    return version_str
-
-
 def _find_update_info(
     app_name: str,
     update_infos: list[UpdateInfo],
@@ -1395,26 +1220,6 @@ def _find_update_info(
     )
 
 
-def display_update_progress(message: str) -> None:
-    """Display a progress message.
-
-    Args:
-        message: Progress message to display.
-
-    """
-    logger.info("🔄 %s", message)
-
-
-def display_update_success(message: str) -> None:
-    """Display a success message.
-
-    Args:
-        message: Success message to display.
-
-    """
-    logger.info("✅ %s", message)
-
-
 def display_update_error(message: str) -> None:
     """Display an error message.
 
@@ -1423,16 +1228,6 @@ def display_update_error(message: str) -> None:
 
     """
     logger.error("❌ %s", message)
-
-
-def display_update_warning(message: str) -> None:
-    """Display a warning message.
-
-    Args:
-        message: Warning message to display.
-
-    """
-    logger.warning("⚠️  %s", message)
 
 
 def display_check_results(results: dict) -> None:
@@ -1491,8 +1286,8 @@ def display_update_results(results: dict) -> None:  # noqa: C901, PLR0912
             logger.info("%-25s ❌ Update failed", app_name)
             # Keep error reason indented under the app name
             # app name is already shown in the log line above
-            if app_info.error_reason:
-                logger.info("%25s    → %s", "", app_info.error_reason)
+            if app_info and app_info.error_reason:
+                logger.info("%-25s    → %s", "", app_info.error_reason)
 
         # Show up-to-date apps
         for app_name in up_to_date:

--- a/src/my_unicorn/core/update.py
+++ b/src/my_unicorn/core/update.py
@@ -1262,7 +1262,7 @@ def _display_update_operation_summary(
 
     # Show summary stats
     if updated_count > 0:
-        logger.info("🎉 Successfully updated %s app(s)", updated_count)
+        logger.info("\n🎉 Successfully updated %s app(s)", updated_count)
     if failed_count > 0:
         logger.info("❌ %s app(s) failed to update", failed_count)
 
@@ -1509,7 +1509,7 @@ def display_update_results(results: dict) -> None:  # noqa: C901, PLR0912
 
         # Show summary stats
         if updated:
-            logger.info("🎉 Successfully updated %s app(s)", len(updated))
+            logger.info("\n🎉 Successfully updated %s app(s)", len(updated))
         if failed:
             logger.info("❌ %s app(s) failed to update", len(failed))
         if up_to_date:

--- a/src/my_unicorn/main.py
+++ b/src/my_unicorn/main.py
@@ -21,7 +21,7 @@ async def async_main() -> None:
     Initialize the CLI runner and execute the main command loop
     asynchronously.
     """
-    logger.info("CLI started")
+    logger.debug("CLI started")
     runner = CLIRunner()
     try:
         await runner.run()

--- a/src/my_unicorn/utils/__init__.py
+++ b/src/my_unicorn/utils/__init__.py
@@ -3,7 +3,7 @@
 This package provides common utility functions including:
 - Asset validation (is_appimage_file, is_checksum_file, get_checksum_file_format_type)
 - Progress utilities (human_mib, human_speed_bps, format_eta)
-- Update display functions (display_update_summary, display_update_error)
+- Update display functions (display_update_error)
 
 Note: Functions have been reorganized following DRY principles:
 - Asset validation -> utils/asset_validation.py (shared across layers)

--- a/tests/core/update/test_update_displays.py
+++ b/tests/core/update/test_update_displays.py
@@ -4,19 +4,11 @@ from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 from my_unicorn.core.update import (
-    _display_check_only_summary,
     _find_update_info,
-    _format_update_version_info,
-    _get_update_status,
     display_check_results,
     display_invalid_apps,
-    display_update_details,
     display_update_error,
-    display_update_progress,
     display_update_results,
-    display_update_success,
-    display_update_summary,
-    display_update_warning,
 )
 
 
@@ -34,227 +26,6 @@ class MockUpdateInfo:
     def is_success(self) -> bool:
         """Return whether the mock represents a successful update check."""
         return self.error_reason is None
-
-
-class TestDisplayUpdateSummary:
-    """Tests for display_update_summary function."""
-
-    def test_display_update_summary_no_apps(self, caplog):
-        """Test display_update_summary with no apps."""
-        display_update_summary([], [], [], [], check_only=False)
-
-        captured = caplog.text
-        assert "No apps to process." in captured
-
-    def test_display_update_summary_check_only(self, caplog):
-        """Test display_update_summary in check-only mode."""
-        update_infos = [
-            MockUpdateInfo("app1", "1.0.0", "2.0.0", has_update=True),
-            MockUpdateInfo("app2", "1.0.0", "1.0.0", has_update=False),
-        ]
-
-        display_update_summary([], [], [], update_infos, check_only=True)
-
-        captured = caplog.text
-        assert "Check Summary:" in captured
-        assert "Total apps checked: 2" in captured
-        assert "Updates available: 1" in captured
-        assert "Up to date: 1" in captured
-        assert "app1: 1.0.0 → 2.0.0" in captured
-
-    def test_display_update_summary_update_operation(self, caplog):
-        """Test display_update_summary for update operation."""
-        update_infos = [
-            MockUpdateInfo("app1", "1.0.0", "2.0.0", has_update=True),
-            MockUpdateInfo("app2", "1.0.0", "1.0.0", has_update=False),
-        ]
-        updated_apps = ["app1"]
-        failed_apps = []
-        up_to_date_apps = ["app2"]
-
-        display_update_summary(
-            updated_apps,
-            failed_apps,
-            up_to_date_apps,
-            update_infos,
-            check_only=False,
-        )
-
-        captured = caplog.text
-        assert "Update Summary:" in captured
-        assert "app1" in captured
-        assert "✅" in captured
-        assert "1.0.0 → 2.0.0" in captured
-        assert "Successfully updated 1 app(s)" in captured
-
-    def test_display_update_summary_with_failures(self, caplog):
-        """Test display_update_summary with failed updates."""
-        update_infos = [
-            MockUpdateInfo(
-                "app1",
-                "1.0.0",
-                "2.0.0",
-                has_update=True,
-                error_reason="Network error",
-            ),
-        ]
-        updated_apps = []
-        failed_apps = ["app1"]
-        up_to_date_apps = []
-
-        display_update_summary(
-            updated_apps,
-            failed_apps,
-            up_to_date_apps,
-            update_infos,
-            check_only=False,
-        )
-
-        captured = caplog.text
-        assert "Update Summary:" in captured
-        assert "app1" in captured
-        assert "❌ Update failed" in captured
-        assert "Network error" in captured
-        assert "1 app(s) failed to update" in captured
-
-
-class TestDisplayCheckOnlySummary:
-    """Tests for _display_check_only_summary function."""
-
-    def test_display_check_only_summary_no_apps(self, caplog):
-        """Test _display_check_only_summary with no apps."""
-        _display_check_only_summary([])
-
-        captured = caplog.text
-        assert "No apps to check." in captured
-
-    def test_display_check_only_summary_with_updates(self, caplog):
-        """Test _display_check_only_summary with apps having updates."""
-        update_infos = [
-            MockUpdateInfo("app1", "1.0.0", "2.0.0", has_update=True),
-            MockUpdateInfo("app2", "1.5.0", "2.5.0", has_update=True),
-            MockUpdateInfo("app3", "1.0.0", "1.0.0", has_update=False),
-        ]
-
-        _display_check_only_summary(update_infos)
-
-        captured = caplog.text
-        assert "Check Summary:" in captured
-        assert "Total apps checked: 3" in captured
-        assert "Updates available: 2" in captured
-        assert "Up to date: 1" in captured
-        assert "Apps with updates available:" in captured
-        assert "app1: 1.0.0 → 2.0.0" in captured
-        assert "app2: 1.5.0 → 2.5.0" in captured
-
-    def test_display_check_only_summary_no_updates(self, caplog):
-        """Test _display_check_only_summary with no updates available."""
-        update_infos = [
-            MockUpdateInfo("app1", "1.0.0", "1.0.0", has_update=False),
-            MockUpdateInfo("app2", "2.0.0", "2.0.0", has_update=False),
-        ]
-
-        _display_check_only_summary(update_infos)
-
-        captured = caplog.text
-        assert "Total apps checked: 2" in captured
-        assert "Updates available: 0" in captured
-        assert "Up to date: 2" in captured
-        # Should not show "Apps with updates available" section
-        assert "Apps with updates available:" not in captured
-
-
-class TestDisplayUpdateDetails:
-    """Tests for display_update_details function."""
-
-    def test_display_update_details_no_info(self, caplog):
-        """Test display_update_details with no information."""
-        display_update_details([], [], [])
-
-        captured = caplog.text
-        assert "No update information available." in captured
-
-    def test_display_update_details_with_data(self, caplog):
-        """Test display_update_details with complete data."""
-        update_infos = [
-            MockUpdateInfo("app1", "1.0.0", "2.0.0", has_update=True),
-            MockUpdateInfo("app2", "1.0.0", "1.0.0", has_update=False),
-            MockUpdateInfo("app3", "1.0.0", "2.0.0", has_update=True),
-        ]
-        updated_apps = ["app1"]
-        failed_apps = ["app3"]
-
-        display_update_details(updated_apps, failed_apps, update_infos)
-
-        captured = caplog.text
-        assert "Detailed Results:" in captured
-        assert "App Name" in captured
-        assert "Status" in captured
-        assert "Version Info" in captured
-        assert "app1" in captured
-        assert "app2" in captured
-        assert "app3" in captured
-
-
-class TestGetUpdateStatus:
-    """Tests for _get_update_status function."""
-
-    def test_get_update_status_updated(self):
-        """Test _get_update_status for updated app."""
-        info = MockUpdateInfo("app1", "1.0.0", "2.0.0", has_update=True)
-        status = _get_update_status(info, ["app1"], [])
-
-        assert status == "✅ Updated"
-
-    def test_get_update_status_failed(self):
-        """Test _get_update_status for failed app."""
-        info = MockUpdateInfo("app1", "1.0.0", "2.0.0", has_update=True)
-        status = _get_update_status(info, [], ["app1"])
-
-        assert status == "❌ Failed"
-
-    def test_get_update_status_update_available(self):
-        """Test _get_update_status for app with update available."""
-        info = MockUpdateInfo("app1", "1.0.0", "2.0.0", has_update=True)
-        status = _get_update_status(info, [], [])
-
-        assert status == "📦 Update available"
-
-    def test_get_update_status_up_to_date(self):
-        """Test _get_update_status for up-to-date app."""
-        info = MockUpdateInfo("app1", "1.0.0", "1.0.0", has_update=False)
-        status = _get_update_status(info, [], [])
-
-        assert status == "✅ Up to date"
-
-
-class TestFormatUpdateVersionInfo:
-    """Tests for _format_update_version_info function."""
-
-    def test_format_update_version_info_with_update(self):
-        """Test _format_update_version_info with update available."""
-        info = MockUpdateInfo("app1", "1.0.0", "2.0.0", has_update=True)
-        version_str = _format_update_version_info(info)
-
-        assert version_str == "1.0.0 → 2.0.0"
-
-    def test_format_update_version_info_no_update(self):
-        """Test _format_update_version_info without update."""
-        info = MockUpdateInfo("app1", "1.0.0", "1.0.0", has_update=False)
-        version_str = _format_update_version_info(info)
-
-        assert version_str == "1.0.0"
-
-    def test_format_update_version_info_long_string(self):
-        """Test _format_update_version_info with long version string."""
-        long_version = "1.0.0-very-long-version-string-that-exceeds-limit"
-        info = MockUpdateInfo(
-            "app1", long_version, long_version, has_update=False
-        )
-        version_str = _format_update_version_info(info)
-
-        assert len(version_str) <= 40
-        assert version_str.endswith("...")
 
 
 class TestFindUpdateInfo:
@@ -290,33 +61,12 @@ class TestFindUpdateInfo:
 class TestDisplayMessageFunctions:
     """Tests for display message functions."""
 
-    def test_display_update_progress(self, caplog):
-        """Test display_update_progress function."""
-        display_update_progress("Processing app1...")
-
-        captured = caplog.text
-        assert "🔄 Processing app1..." in captured
-
-    def test_display_update_success(self, caplog):
-        """Test display_update_success function."""
-        display_update_success("App updated successfully")
-
-        captured = caplog.text
-        assert "✅ App updated successfully" in captured
-
     def test_display_update_error(self, caplog):
         """Test display_update_error function."""
         display_update_error("Update failed")
 
         captured = caplog.text
         assert "❌ Update failed" in captured
-
-    def test_display_update_warning(self, caplog):
-        """Test display_update_warning function."""
-        display_update_warning("Low disk space")
-
-        captured = caplog.text
-        assert "⚠️  Low disk space" in captured
 
 
 class TestDisplayCheckResults:

--- a/tests/fixtures/expected_ui_output/update_summary.txt
+++ b/tests/fixtures/expected_ui_output/update_summary.txt
@@ -1,0 +1,10 @@
+📦 Update Summary:
+--------------------------------------------------
+qownnotes                 ✅ 26.5.1 → 26.5.4
+ytmdesktop                ❌ Update failed
+                             → AppImage not found in release - may still be building
+appflowy                  ℹ️  Already up to date (0.11.8)
+
+🎉 Successfully updated 1 app(s)
+❌ 1 app(s) failed to update
+ℹ️  1 app(s) already up to date

--- a/tests/integration/progress/test_summary_ui.py
+++ b/tests/integration/progress/test_summary_ui.py
@@ -8,6 +8,7 @@ icons, and version change display.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -561,3 +562,83 @@ class TestSummaryUIFixtureValidation:
             install_success_output, "📦 Installation Summary:"
         )
         assert fixture_summary != "", "Summary section missing from fixture"
+
+
+@pytest.fixture
+def update_summary_full_output() -> str:
+    fixture_path = (
+        Path(__file__).resolve().parents[2] 
+        / "fixtures"
+        / "expected_ui_output"
+        / "update_summary.txt"
+    )
+    return fixture_path.read_text()
+
+
+@pytest.mark.integration
+class TestUpdateSummaryFullUI:
+    """End-to-end UI validation for full update summary output."""
+
+    def test_update_summary_full_ui_matches_fixture(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        update_summary_full_output: str,
+    ) -> None:
+        """Verify full Update Summary UI matches fixture exactly."""
+
+        # Arrange
+        update_infos = [
+            UpdateInfo(
+                app_name="qownnotes",
+                current_version="26.5.1",
+                latest_version="26.5.4",
+                prerelease=False,
+                error_reason=None,
+            ),
+            UpdateInfo(
+                app_name="ytmdesktop",
+                current_version=None,
+                latest_version=None,
+                prerelease=False,
+                error_reason=(
+                    "AppImage not found in release - may still be building"
+                ),
+            ),
+            UpdateInfo(
+                app_name="appflowy",
+                current_version="0.11.8",
+                latest_version="0.11.8",
+                prerelease=False,
+                error_reason=None,
+            ),
+        ]
+
+        results = {
+            "updated": ["qownnotes"],
+            "failed": ["ytmdesktop"],
+            "up_to_date": ["appflowy"],
+            "update_infos": update_infos,
+        }
+
+        # Act
+        output = _capture_log_output(
+            _display_update_results,
+            results,
+            caplog=caplog,
+        )
+
+        # Extract summary
+        summary = _extract_summary_section(
+            output,
+            "📦 Update Summary:",
+        )
+        assert summary != "", "Summary section not found"
+
+        # Normalize
+        normalized_summary = normalize_output_for_comparison(summary)
+        normalized_expected = normalize_output_for_comparison(
+            update_summary_full_output
+        )
+
+        # Assert
+        assert normalized_summary.strip() == normalized_expected.strip()


### PR DESCRIPTION


## Problem



The UI quickly clears error messages in the API section, leading to confusion when multiple app updates fail. This behavior results in duplicate "Fetching from API:" messages and makes it difficult for users to see relevant error information.



## Solution



Adjust the logging level for missing AppImage errors to debug, allowing users to see the error in the summary section without cluttering the API section. This change prevents the UI from displaying duplicate fetching messages and improves overall clarity.



## Type of Change



- [x] Bug fix



## Checklist



- If you changed python module:

- [ ] Run all fast tests: `uv run pytest -m 'not slow'`

- [ ] Run e2e tests: `uv run pytest tests/e2e/` (WARNING: This tests would use real api connection, make sure you setup your token. Also, this would take time according to your internet speed.)

- [ ] Add your test (if you can)

- [ ] Add/update docs

